### PR TITLE
Component Id and Detector Id types added

### DIFF
--- a/cow_instrument/CMakeLists.txt
+++ b/cow_instrument/CMakeLists.txt
@@ -23,6 +23,7 @@ set ( INCLUDE_FILES
                    Node.h
                    NodeIterator.h
                    NullComponent.h
+                   IntToType.h
 )
 
 add_library (cow_instrument SHARED ${SOURCE_FILES} ${INCLUDE_FILES})

--- a/cow_instrument/Component.h
+++ b/cow_instrument/Component.h
@@ -3,10 +3,13 @@
 
 #include <array>
 #include <map>
+#include "IntToType.h"
 
 using V3D = std::array<double, 3>;
 
 class Detector;
+
+using ComponentIdType = IntToType<0, size_t>;
 
 class Component {
 public:
@@ -16,6 +19,7 @@ public:
   virtual Component* clone() const = 0;
   virtual bool equals(const Component& other) const = 0;
   virtual void registerDetectors(std::map<size_t, const Detector*>& lookup) const = 0;
+  virtual ComponentIdType componentId() const = 0;
 };
 
 #endif

--- a/cow_instrument/Component.h
+++ b/cow_instrument/Component.h
@@ -18,7 +18,7 @@ public:
   virtual ~Component(){}
   virtual Component* clone() const = 0;
   virtual bool equals(const Component& other) const = 0;
-  virtual void registerDetectors(std::map<size_t, const Detector*>& lookup) const = 0;
+  virtual void registerContents(std::map<size_t, const Detector*>& lookup) const = 0;
   virtual ComponentIdType componentId() const = 0;
 };
 

--- a/cow_instrument/CompositeComponent.cpp
+++ b/cow_instrument/CompositeComponent.cpp
@@ -1,6 +1,11 @@
 #include "CompositeComponent.h"
 #include "Detector.h"
 
+CompositeComponent::CompositeComponent(ComponentIdType componentId) : m_componentId(componentId)
+{
+
+}
+
 V3D CompositeComponent::getPos() const {
 
   /*
@@ -27,7 +32,7 @@ void CompositeComponent::deltaPos(const V3D &delta) {
 }
 
 CompositeComponent *CompositeComponent::clone() const {
-  CompositeComponent *product = new CompositeComponent;
+  CompositeComponent *product = new CompositeComponent{m_componentId};
   for (size_t i = 0; i < this->size(); ++i) {
     product->addComponent(std::shared_ptr<Component>(m_children[i]->clone()));
   }
@@ -67,4 +72,9 @@ void CompositeComponent::registerDetectors(std::map<size_t, const Detector *> &l
     for(auto& child : m_children){
         child->registerDetectors(lookup);
     }
+}
+
+ComponentIdType CompositeComponent::componentId() const
+{
+    return m_componentId;
 }

--- a/cow_instrument/CompositeComponent.cpp
+++ b/cow_instrument/CompositeComponent.cpp
@@ -67,10 +67,10 @@ CompositeComponent::getChild(size_t index) const {
   }
 }
 
-void CompositeComponent::registerDetectors(std::map<size_t, const Detector *> &lookup) const
+void CompositeComponent::registerContents(std::map<size_t, const Detector *> &lookup) const
 {
     for(auto& child : m_children){
-        child->registerDetectors(lookup);
+        child->registerContents(lookup);
     }
 }
 

--- a/cow_instrument/CompositeComponent.h
+++ b/cow_instrument/CompositeComponent.h
@@ -18,7 +18,7 @@ public:
   void addComponent(std::shared_ptr<Component> child);
   size_t size() const {return m_children.size();}
   std::shared_ptr<const Component> getChild(size_t index) const;
-  void registerDetectors(std::map<size_t, const Detector*>& lookup) const override;
+  void registerContents(std::map<size_t, const Detector*>& lookup) const override;
   ComponentIdType componentId() const override;
 private:
   const ComponentIdType m_componentId;

--- a/cow_instrument/CompositeComponent.h
+++ b/cow_instrument/CompositeComponent.h
@@ -9,7 +9,7 @@ class Detector;
 
 class CompositeComponent : public Component {
 public:
-  CompositeComponent() = default;
+  CompositeComponent(ComponentIdType componentId);
   ~CompositeComponent() = default;
   V3D getPos() const override;
   void deltaPos(const V3D &pos) override;
@@ -19,9 +19,12 @@ public:
   size_t size() const {return m_children.size();}
   std::shared_ptr<const Component> getChild(size_t index) const;
   void registerDetectors(std::map<size_t, const Detector*>& lookup) const override;
-
+  ComponentIdType componentId() const override;
 private:
+  const ComponentIdType m_componentId;
   std::vector<std::shared_ptr<Component>> m_children;
+
+
 };
 
 using CompositeComponent_sptr = std::shared_ptr<CompositeComponent>;

--- a/cow_instrument/Detector.h
+++ b/cow_instrument/Detector.h
@@ -2,13 +2,16 @@
 #define DETECTOR_H
 
 #include "Component.h"
+#include "IntToType.h"
+
+using DetectorIdType = IntToType<1, size_t>;
 
 /**
  * Pure abstract detector
  */
 class Detector : public Component {
 public:
-    virtual size_t detectorId() const = 0;
+    virtual DetectorIdType detectorId() const = 0;
     virtual ~Detector(){}
 };
 

--- a/cow_instrument/Detector.h
+++ b/cow_instrument/Detector.h
@@ -8,7 +8,7 @@
  */
 class Detector : public Component {
 public:
-    virtual size_t id() const = 0;
+    virtual size_t detectorId() const = 0;
     virtual ~Detector(){}
 };
 

--- a/cow_instrument/DetectorComponent.cpp
+++ b/cow_instrument/DetectorComponent.cpp
@@ -25,7 +25,7 @@ bool DetectorComponent::equals(const Component &other) const {
   return false;
 }
 
-void DetectorComponent::registerDetectors(
+void DetectorComponent::registerContents(
     std::map<size_t, const Detector *> &lookup) const {
   lookup.insert(std::make_pair(this->detectorId().const_ref(), this));
 }

--- a/cow_instrument/DetectorComponent.cpp
+++ b/cow_instrument/DetectorComponent.cpp
@@ -1,7 +1,7 @@
 #include "DetectorComponent.h"
 
-DetectorComponent::DetectorComponent(ComponentIdType componentId, size_t detectorId,
-                                     const V3D &pos)
+DetectorComponent::DetectorComponent(ComponentIdType componentId,
+                                     DetectorIdType detectorId, const V3D &pos)
     : m_componentId(componentId), m_detectorId(detectorId), m_pos(pos) {}
 
 V3D DetectorComponent::getPos() const { return m_pos; }
@@ -14,7 +14,8 @@ void DetectorComponent::deltaPos(const V3D &delta) {
 
 DetectorComponent *DetectorComponent::clone() const {
 
-  return new DetectorComponent(this->m_componentId, this->m_detectorId, this->m_pos);
+  return new DetectorComponent(this->m_componentId, this->m_detectorId,
+                               this->m_pos);
 }
 
 bool DetectorComponent::equals(const Component &other) const {
@@ -26,11 +27,11 @@ bool DetectorComponent::equals(const Component &other) const {
 
 void DetectorComponent::registerDetectors(
     std::map<size_t, const Detector *> &lookup) const {
-  lookup.insert(std::make_pair(this->detectorId(), this));
+  lookup.insert(std::make_pair(this->detectorId().const_ref(), this));
 }
 
 DetectorComponent::~DetectorComponent() {}
 
-size_t DetectorComponent::detectorId() const { return m_detectorId; }
+DetectorIdType DetectorComponent::detectorId() const { return m_detectorId; }
 
 ComponentIdType DetectorComponent::componentId() const { return m_componentId; }

--- a/cow_instrument/DetectorComponent.cpp
+++ b/cow_instrument/DetectorComponent.cpp
@@ -1,6 +1,8 @@
 #include "DetectorComponent.h"
 
-DetectorComponent::DetectorComponent(size_t id, const V3D &pos) : m_id(id), m_pos(pos) {}
+DetectorComponent::DetectorComponent(ComponentIdType componentId, size_t detectorId,
+                                     const V3D &pos)
+    : m_componentId(componentId), m_detectorId(detectorId), m_pos(pos) {}
 
 V3D DetectorComponent::getPos() const { return m_pos; }
 
@@ -12,19 +14,23 @@ void DetectorComponent::deltaPos(const V3D &delta) {
 
 DetectorComponent *DetectorComponent::clone() const {
 
-  return new DetectorComponent(this->m_id, this->m_pos);
+  return new DetectorComponent(this->m_componentId, this->m_detectorId, this->m_pos);
 }
 
 bool DetectorComponent::equals(const Component &other) const {
   if (auto *otherDetector = dynamic_cast<const DetectorComponent *>(&other)) {
-    return otherDetector->id() == this->id();
+    return otherDetector->detectorId() == this->detectorId();
   }
   return false;
 }
 
-void DetectorComponent::registerDetectors(std::map<size_t, const Detector *> &lookup) const
-{
-    lookup.insert(std::make_pair(this->id(), this));
+void DetectorComponent::registerDetectors(
+    std::map<size_t, const Detector *> &lookup) const {
+  lookup.insert(std::make_pair(this->detectorId(), this));
 }
 
 DetectorComponent::~DetectorComponent() {}
+
+size_t DetectorComponent::detectorId() const { return m_detectorId; }
+
+ComponentIdType DetectorComponent::componentId() const { return m_componentId; }

--- a/cow_instrument/DetectorComponent.h
+++ b/cow_instrument/DetectorComponent.h
@@ -8,7 +8,7 @@ class DetectorComponent : public Detector {
 
 public:
 
-  DetectorComponent(size_t id, const V3D &pos);
+  DetectorComponent(ComponentIdType componentId, size_t detectorId, const V3D &pos);
   DetectorComponent(const DetectorComponent&) = default;
   DetectorComponent& operator=(const DetectorComponent&) = default;
 
@@ -17,11 +17,13 @@ public:
   virtual ~DetectorComponent();
   DetectorComponent* clone() const override;
   bool equals(const Component& other) const override;
-  size_t id() const override{return m_id;}
+  size_t detectorId() const override;
+  ComponentIdType componentId() const override;
   void registerDetectors(std::map<size_t, const Detector*>& lookup) const override;
 
 private:
-  size_t m_id;
+  const size_t m_detectorId;
+  const ComponentIdType m_componentId;
   V3D m_pos;
 
 

--- a/cow_instrument/DetectorComponent.h
+++ b/cow_instrument/DetectorComponent.h
@@ -20,7 +20,7 @@ public:
   DetectorIdType detectorId() const override;
   ComponentIdType componentId() const override;
   void
-  registerDetectors(std::map<size_t, const Detector *> &lookup) const override;
+  registerContents(std::map<size_t, const Detector *> &lookup) const override;
 
 private:
   const DetectorIdType m_detectorId;

--- a/cow_instrument/DetectorComponent.h
+++ b/cow_instrument/DetectorComponent.h
@@ -7,26 +7,25 @@
 class DetectorComponent : public Detector {
 
 public:
-
-  DetectorComponent(ComponentIdType componentId, size_t detectorId, const V3D &pos);
-  DetectorComponent(const DetectorComponent&) = default;
-  DetectorComponent& operator=(const DetectorComponent&) = default;
+  DetectorComponent(ComponentIdType componentId, DetectorIdType detectorId,
+                    const V3D &pos);
+  DetectorComponent(const DetectorComponent &) = default;
+  DetectorComponent &operator=(const DetectorComponent &) = default;
 
   V3D getPos() const override;
   void deltaPos(const V3D &pos) override;
   virtual ~DetectorComponent();
-  DetectorComponent* clone() const override;
-  bool equals(const Component& other) const override;
-  size_t detectorId() const override;
+  DetectorComponent *clone() const override;
+  bool equals(const Component &other) const override;
+  DetectorIdType detectorId() const override;
   ComponentIdType componentId() const override;
-  void registerDetectors(std::map<size_t, const Detector*>& lookup) const override;
+  void
+  registerDetectors(std::map<size_t, const Detector *> &lookup) const override;
 
 private:
-  const size_t m_detectorId;
+  const DetectorIdType m_detectorId;
   const ComponentIdType m_componentId;
   V3D m_pos;
-
-
 };
 
 #endif

--- a/cow_instrument/InstrumentTree.cpp
+++ b/cow_instrument/InstrumentTree.cpp
@@ -12,7 +12,7 @@ void findDetectors(const Component &component,
                    std::map<size_t, const Detector *> &store) {
 
   // Walk through and register all detectors on the store.
-  component.registerDetectors(store);
+  component.registerContents(store);
 }
 }
 

--- a/cow_instrument/InstrumentTree.cpp
+++ b/cow_instrument/InstrumentTree.cpp
@@ -16,10 +16,12 @@ void findDetectors(const Component &component,
 }
 }
 
-InstrumentTree::InstrumentTree(Node_const_uptr&& root) : m_root(std::move(root)) {
+InstrumentTree::InstrumentTree(Node_const_uptr &&root)
+    : m_root(std::move(root)) {
 
-  if(!m_root){
-      throw std::invalid_argument("No root Node. Cannot create an InstrumentTree");
+  if (!m_root) {
+    throw std::invalid_argument(
+        "No root Node. Cannot create an InstrumentTree");
   }
 
   const unsigned int expectedVersion = this->version();
@@ -40,7 +42,7 @@ std::unique_ptr<NodeIterator> InstrumentTree::iterator() const {
   return std::unique_ptr<NodeIterator>(new NodeIterator(m_root->clone()));
 }
 
-const Node& InstrumentTree::root() const { return *m_root; }
+const Node &InstrumentTree::root() const { return *m_root; }
 
 const Detector &InstrumentTree::getDetector(size_t detectorId) const {
 
@@ -50,6 +52,10 @@ const Detector &InstrumentTree::getDetector(size_t detectorId) const {
                                 std::to_string(detectorId));
   }
   return *(it->second);
+}
+
+const Detector &InstrumentTree::getDetector(DetectorIdType detectorId) const {
+  return getDetector(detectorId.const_ref());
 }
 
 unsigned int InstrumentTree::version() const { return m_root->version(); }

--- a/cow_instrument/InstrumentTree.h
+++ b/cow_instrument/InstrumentTree.h
@@ -3,33 +3,32 @@
 
 #include <memory>
 #include <map>
+#include "Detector.h"
 
 class Node;
 class NodeIterator;
-class Detector;
 
 /*
  The instrument is nothing more than syntatic sugar over the root Node.
  */
 class InstrumentTree {
 public:
+  InstrumentTree(std::unique_ptr<const Node> &&root);
 
-    InstrumentTree(std::unique_ptr<const Node>&& root);
+  std::unique_ptr<NodeIterator> iterator() const;
 
-    std::unique_ptr<NodeIterator> iterator() const;
+  const Node &root() const;
 
-    const Node& root() const;
+  const Detector &getDetector(size_t detectorId) const;
 
-    const Detector& getDetector(size_t detectorId) const;
+  const Detector &getDetector(DetectorIdType detectorId) const;
 
-    unsigned int version() const;
+      unsigned int version() const;
 
 private:
+  std::map<size_t, Detector const *> m_detectorMap;
 
-    std::map<size_t, Detector const *> m_detectorMap;
-
-    std::unique_ptr<const Node> m_root;
-
+  std::unique_ptr<const Node> m_root;
 };
 
 #endif

--- a/cow_instrument/IntToType.h
+++ b/cow_instrument/IntToType.h
@@ -26,6 +26,12 @@ public:
       ++value;
       return temp;
   }
+  const T& const_ref(){
+      return value;
+  }
+  IntToType<I, T> operator+(const T & increment){
+      return IntToType<I,T>(value+increment);
+  }
 
 private:
   T value;

--- a/cow_instrument/IntToType.h
+++ b/cow_instrument/IntToType.h
@@ -3,6 +3,13 @@
 
 #include <memory>
 
+/**
+ This allows us to simply create unique types holding a T. I simply enforces
+ that concrete types made from IntToType are incompatible.
+
+ Typical usage:
+        using MyUniqueDouble = IntToType<0, double>;
+ */
 template <int I, typename T> class IntToType {
 public:
   explicit IntToType(const T &val) : value(val) {}

--- a/cow_instrument/IntToType.h
+++ b/cow_instrument/IntToType.h
@@ -1,0 +1,35 @@
+#ifndef INT_TO_TYPE
+#define INT_TO_TYPE
+
+#include <memory>
+
+template <int I, typename T> class IntToType {
+public:
+  explicit IntToType(const T &val) : value(val) {}
+  explicit IntToType(T &&val) : value(val) {}
+  IntToType(const IntToType<I, T> &other) : value(other.value) {}
+  IntToType<I, T> &operator=(const IntToType<I, T> &other) {
+    value = other.value;
+    return *this;
+  }
+  bool operator==(const IntToType<I, T> &other) const {
+    return value == other.value;
+  }
+  IntToType<I, T>& operator++()
+  {
+       ++value;
+      return this;
+  }
+  IntToType<I, T> operator++(int)
+  {
+      IntToType<I,T> temp(value);
+      ++value;
+      return temp;
+  }
+
+private:
+  T value;
+  enum { typeValue = I };
+};
+
+#endif

--- a/cow_instrument/NullComponent.cpp
+++ b/cow_instrument/NullComponent.cpp
@@ -12,7 +12,7 @@ bool NullComponent::equals(const Component& other) const{
     return dynamic_cast<const NullComponent*>(&other) != nullptr;
 }
 
-void NullComponent::registerDetectors(std::map<size_t, const Detector *> &) const
+void NullComponent::registerContents(std::map<size_t, const Detector *> &) const
 {
 }
 

--- a/cow_instrument/NullComponent.cpp
+++ b/cow_instrument/NullComponent.cpp
@@ -15,3 +15,8 @@ bool NullComponent::equals(const Component& other) const{
 void NullComponent::registerDetectors(std::map<size_t, const Detector *> &) const
 {
 }
+
+ComponentIdType NullComponent::componentId() const
+{
+    throw std::runtime_error("NullComponent does not implement componentId");
+}

--- a/cow_instrument/NullComponent.h
+++ b/cow_instrument/NullComponent.h
@@ -11,7 +11,7 @@ public:
   virtual ~NullComponent();
   NullComponent *clone() const override;
   bool equals(const Component &other) const override;
-  void registerDetectors(std::map<size_t, const Detector *> &lookup) const override;
+  void registerContents(std::map<size_t, const Detector *> &lookup) const override;
   ComponentIdType componentId() const override;
 };
 

--- a/cow_instrument/NullComponent.h
+++ b/cow_instrument/NullComponent.h
@@ -12,6 +12,7 @@ public:
   NullComponent *clone() const override;
   bool equals(const Component &other) const override;
   void registerDetectors(std::map<size_t, const Detector *> &lookup) const override;
+  ComponentIdType componentId() const override;
 };
 
 #endif

--- a/cow_instrument/testing/CompositeComponentTest.cpp
+++ b/cow_instrument/testing/CompositeComponentTest.cpp
@@ -7,12 +7,12 @@ using namespace testing;
 namespace {
 
 TEST(composite_component_test, test_construction){
-    CompositeComponent composite;
+    CompositeComponent composite{ComponentIdType(1)};
     EXPECT_EQ(0, composite.size());
 }
 
 TEST(composite_component_test, test_clone){
-    CompositeComponent composite;
+    CompositeComponent composite{ComponentIdType(1)};
 
     MockComponent* childA = new MockComponent;
     EXPECT_CALL(*childA, clone()).WillRepeatedly(Return(new MockComponent));
@@ -37,7 +37,7 @@ TEST(composite_component_test, test_get_pos){
     MockComponent* childC = new MockComponent;
     EXPECT_CALL(*childC, getPos()).WillRepeatedly(Return(V3D{3,3,3}));
 
-    CompositeComponent composite;
+    CompositeComponent composite{ComponentIdType(1)};
     composite.addComponent(std::shared_ptr<MockComponent>(childA));
     composite.addComponent(std::shared_ptr<MockComponent>(childB));
     composite.addComponent(std::shared_ptr<MockComponent>(childC));

--- a/cow_instrument/testing/DetectorComponentTest.cpp
+++ b/cow_instrument/testing/DetectorComponentTest.cpp
@@ -12,40 +12,37 @@ namespace {
 TEST(detector_component_test, test_construction) {
 
   V3D input{1, 2, 3};
-  size_t id = 1;
-  DetectorComponent det(ComponentIdType(1), id, input);
+  DetectorIdType det_id(1);
+  ComponentIdType comp_id(1);
+  DetectorComponent det(comp_id, det_id, input);
   EXPECT_EQ(det.getPos(), input);
-  EXPECT_EQ(det.detectorId(), id);
-  EXPECT_EQ(det.componentId(), ComponentIdType(1));
+  EXPECT_EQ(det.detectorId(), det_id);
+  EXPECT_EQ(det.componentId(), comp_id);
 }
 
-TEST(detector_component_test, test_equals){
+TEST(detector_component_test, test_equals) {
 
-    V3D input{1, 2, 3};
-    DetectorComponent a(ComponentIdType(1), 1, input);
-    DetectorComponent b(ComponentIdType(2), 2, input); // Different id.
+  V3D input{1, 2, 3};
+  DetectorComponent a(ComponentIdType(1), DetectorIdType(1), input);
+  DetectorComponent b(ComponentIdType(2), DetectorIdType(2), input); // Different id.
 
-    EXPECT_FALSE(a.equals(b));
+  EXPECT_FALSE(a.equals(b));
 
-    MockComponent c;
-    EXPECT_FALSE(a.equals(c));
+  MockComponent c;
+  EXPECT_FALSE(a.equals(c));
 
-    DetectorComponent d(ComponentIdType(3), 1, input);
-    EXPECT_TRUE(a.equals(d));
+  DetectorComponent d(ComponentIdType(3), DetectorIdType(1), input);
+  EXPECT_TRUE(a.equals(d));
 }
 
-TEST(detector_component_test, test_clone){
-    V3D input{1, 2, 3};
-    DetectorComponent det(ComponentIdType(1), 1, input);
-    DetectorComponent* clone = det.clone();
+TEST(detector_component_test, test_clone) {
+  V3D input{1, 2, 3};
+  DetectorComponent det(ComponentIdType(1), DetectorIdType(1), input);
+  DetectorComponent *clone = det.clone();
 
-    EXPECT_TRUE(det.equals(*clone));
-    EXPECT_NE(&det, clone); // different objects
-    delete clone;
-
+  EXPECT_TRUE(det.equals(*clone));
+  EXPECT_NE(&det, clone); // different objects
+  delete clone;
 }
-
-
-
 
 } // namespace

--- a/cow_instrument/testing/DetectorComponentTest.cpp
+++ b/cow_instrument/testing/DetectorComponentTest.cpp
@@ -13,29 +13,30 @@ TEST(detector_component_test, test_construction) {
 
   V3D input{1, 2, 3};
   size_t id = 1;
-  DetectorComponent det(id, input);
+  DetectorComponent det(ComponentIdType(1), id, input);
   EXPECT_EQ(det.getPos(), input);
-  EXPECT_EQ(det.id(), id);
+  EXPECT_EQ(det.detectorId(), id);
+  EXPECT_EQ(det.componentId(), ComponentIdType(1));
 }
 
 TEST(detector_component_test, test_equals){
 
     V3D input{1, 2, 3};
-    DetectorComponent a(1, input);
-    DetectorComponent b(2, input); // Different id.
+    DetectorComponent a(ComponentIdType(1), 1, input);
+    DetectorComponent b(ComponentIdType(2), 2, input); // Different id.
 
     EXPECT_FALSE(a.equals(b));
 
     MockComponent c;
     EXPECT_FALSE(a.equals(c));
 
-    DetectorComponent d(1, input);
+    DetectorComponent d(ComponentIdType(3), 1, input);
     EXPECT_TRUE(a.equals(d));
 }
 
 TEST(detector_component_test, test_clone){
     V3D input{1, 2, 3};
-    DetectorComponent det(1, input);
+    DetectorComponent det(ComponentIdType(1), 1, input);
     DetectorComponent* clone = det.clone();
 
     EXPECT_TRUE(det.equals(*clone));

--- a/cow_instrument/testing/Example.cpp
+++ b/cow_instrument/testing/Example.cpp
@@ -21,9 +21,10 @@ public:
 
 private:
   CompositeComponent_sptr make_square_bank(size_t width, size_t height) {
-    static size_t detectorId = 1;
+    static DetectorIdType detectorId(1);
     static ComponentIdType componentId(1);
-    CompositeComponent_sptr bank = std::make_shared<CompositeComponent>(ComponentIdType(0));
+    CompositeComponent_sptr bank =
+        std::make_shared<CompositeComponent>(ComponentIdType(0));
     for (size_t i = 0; i < width; ++i) {
       for (size_t j = 0; j < height; ++j) {
         bank->addComponent(std::make_shared<DetectorComponent>(
@@ -112,7 +113,7 @@ TEST_F(ExampleTest, simple_sans_example) {
   size_t max = 100 * 100 * 6;
   double pos_x = 0;
   for (size_t i = 1; i < max; ++i) {
-    const auto &det = m_instrument.getDetector(1);
+    const auto &det = m_instrument.getDetector(i);
     pos_x = det.getPos()[0];
   }
 

--- a/cow_instrument/testing/Example.cpp
+++ b/cow_instrument/testing/Example.cpp
@@ -21,12 +21,13 @@ public:
 
 private:
   CompositeComponent_sptr make_square_bank(size_t width, size_t height) {
-    static size_t id = 1;
-    CompositeComponent_sptr bank = std::make_shared<CompositeComponent>();
+    static size_t detectorId = 1;
+    static ComponentIdType componentId(1);
+    CompositeComponent_sptr bank = std::make_shared<CompositeComponent>(ComponentIdType(0));
     for (size_t i = 0; i < width; ++i) {
       for (size_t j = 0; j < height; ++j) {
         bank->addComponent(std::make_shared<DetectorComponent>(
-            id++, V3D{double(i), double(j), double(0)}));
+            componentId++, detectorId++, V3D{double(i), double(j), double(0)}));
       }
     }
     bank->deltaPos(
@@ -76,8 +77,10 @@ protected:
     Node_uptr nodeS(new Node(front_trolley.get(), CowPtr<Component>(S)));
     Node_uptr nodeW(new Node(front_trolley.get(), CowPtr<Component>(W)));
     Node_uptr rear_trolley(new Node(CowPtr<Component>(new NullComponent)));
-    Node_uptr nodeLCurtain(new Node(rear_trolley.get(), CowPtr<Component>(l_curtain)));
-    Node_uptr nodeRCurtain(new Node(rear_trolley.get(), CowPtr<Component>(r_curtain)));
+    Node_uptr nodeLCurtain(
+        new Node(rear_trolley.get(), CowPtr<Component>(l_curtain)));
+    Node_uptr nodeRCurtain(
+        new Node(rear_trolley.get(), CowPtr<Component>(r_curtain)));
     front_trolley->addChild(std::move(nodeN));
     front_trolley->addChild(std::move(nodeE));
     front_trolley->addChild(std::move(nodeS));
@@ -94,10 +97,9 @@ protected:
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = end - start;
     std::cout << "---------Instrument Tree Construction----------" << std::endl;
-    std::cout << "Creation took " << elapsed_seconds.count() << "seconds" << std::endl;
+    std::cout << "Creation took " << elapsed_seconds.count() << "seconds"
+              << std::endl;
     std::cout << "----------------------------------------" << std::endl;
-
-
   }
 
   virtual ~ExampleTest() {}
@@ -110,14 +112,15 @@ TEST_F(ExampleTest, simple_sans_example) {
   size_t max = 100 * 100 * 6;
   double pos_x = 0;
   for (size_t i = 1; i < max; ++i) {
-    const auto& det = m_instrument.getDetector(1);
+    const auto &det = m_instrument.getDetector(1);
     pos_x = det.getPos()[0];
   }
 
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end - start;
   std::cout << "---------Single Access Metrics----------" << std::endl;
-  std::cout << 100 * 100 * 6 << " accesses took " << elapsed_seconds.count() << "seconds" << std::endl;
+  std::cout << 100 * 100 * 6 << " accesses took " << elapsed_seconds.count()
+            << "seconds" << std::endl;
   std::cout << "----------------------------------------" << std::endl;
 }
 

--- a/cow_instrument/testing/InstrumentTreeTest.cpp
+++ b/cow_instrument/testing/InstrumentTreeTest.cpp
@@ -80,17 +80,16 @@ TEST(instrument_tree_test, test_detector_access) {
   */
 
   Node_uptr a(new Node(CowPtr<Component>(new NiceMock<MockComponent>())));
-
   size_t detector1Id = 1;
-  CompositeComponent_sptr composite = std::make_shared<CompositeComponent>();
+  CompositeComponent_sptr composite = std::make_shared<CompositeComponent>(ComponentIdType(1));
   composite->addComponent(
-      std::make_shared<DetectorComponent>(detector1Id, V3D{1, 1, 1}));
+      std::make_shared<DetectorComponent>(ComponentIdType(detector1Id), detector1Id, V3D{1, 1, 1}));
   Node_uptr b(new Node(a.get(), CowPtr<Component>(composite)));
 
   size_t detector2Id = detector1Id + 1;
   Node_uptr c(
       new Node(a.get(), CowPtr<Component>(std::make_shared<DetectorComponent>(
-                            detector2Id, V3D{2, 2, 2}))));
+                            ComponentIdType(detector2Id), detector2Id, V3D{2, 2, 2}))));
 
   a->addChild(std::move(b));
   a->addChild(std::move(c));
@@ -98,10 +97,10 @@ TEST(instrument_tree_test, test_detector_access) {
   InstrumentTree tree(std::move(a));
 
   const Detector &det1 = tree.getDetector(detector1Id);
-  EXPECT_EQ(det1.id(), detector1Id);
+  EXPECT_EQ(det1.detectorId(), detector1Id);
 
   const Detector &det2 = tree.getDetector(detector2Id);
-  EXPECT_EQ(det2.id(), detector2Id);
+  EXPECT_EQ(det2.detectorId(), detector2Id);
 
   // Ask for something that doesn't exist.
   EXPECT_THROW(tree.getDetector(3), std::invalid_argument);

--- a/cow_instrument/testing/InstrumentTreeTest.cpp
+++ b/cow_instrument/testing/InstrumentTreeTest.cpp
@@ -80,16 +80,16 @@ TEST(instrument_tree_test, test_detector_access) {
   */
 
   Node_uptr a(new Node(CowPtr<Component>(new NiceMock<MockComponent>())));
-  size_t detector1Id = 1;
+  DetectorIdType detector1Id(1);
   CompositeComponent_sptr composite = std::make_shared<CompositeComponent>(ComponentIdType(1));
   composite->addComponent(
-      std::make_shared<DetectorComponent>(ComponentIdType(detector1Id), detector1Id, V3D{1, 1, 1}));
+      std::make_shared<DetectorComponent>(ComponentIdType(1), DetectorIdType(detector1Id), V3D{1, 1, 1}));
   Node_uptr b(new Node(a.get(), CowPtr<Component>(composite)));
 
-  size_t detector2Id = detector1Id + 1;
+  DetectorIdType detector2Id = detector1Id + 1;
   Node_uptr c(
       new Node(a.get(), CowPtr<Component>(std::make_shared<DetectorComponent>(
-                            ComponentIdType(detector2Id), detector2Id, V3D{2, 2, 2}))));
+                            ComponentIdType(2), DetectorIdType(detector2Id), V3D{2, 2, 2}))));
 
   a->addChild(std::move(b));
   a->addChild(std::move(c));

--- a/cow_instrument/testing/MockTypes.h
+++ b/cow_instrument/testing/MockTypes.h
@@ -13,6 +13,7 @@ public:
   MOCK_CONST_METHOD1(equals, bool(const Component &));
   MOCK_CONST_METHOD1(registerDetectors, void(std::map<size_t, const Detector*>&));
   ~MockComponent() {}
+  MOCK_CONST_METHOD0(componentId, ComponentIdType());
 };
 
 class MockCommmand : public Command {

--- a/cow_instrument/testing/MockTypes.h
+++ b/cow_instrument/testing/MockTypes.h
@@ -11,7 +11,7 @@ public:
   MOCK_METHOD1(deltaPos, void(const V3D &));
   MOCK_CONST_METHOD0(clone, Component *());
   MOCK_CONST_METHOD1(equals, bool(const Component &));
-  MOCK_CONST_METHOD1(registerDetectors, void(std::map<size_t, const Detector*>&));
+  MOCK_CONST_METHOD1(registerContents, void(std::map<size_t, const Detector*>&));
   ~MockComponent() {}
   MOCK_CONST_METHOD0(componentId, ComponentIdType());
 };


### PR DESCRIPTION
## What has been done here ##

* A component id has been provided (see justification below)
* The component id and detector id are of completely unique types to prevent misuse at the type level. We have a new `ComponentIdType` and `DetectorIdType` **clients are expected to directly work with these types**

## Justification future-looking ##

Flight paths thread from `Component` to `Component` and arrive at a `Detector`. This forms a network across the instrument tree for each `Detector`. However in the new design, `Components` are isolated from other components via the `Node`. Stated again, `Components` in the new design have no way to reference other `Components`. `Nodes` deliberately isolate components so that internal copying and mutability can be properly managed. Introducing an `component_id` is one mechanism via which components in a chain might be looked-up. 

Each `FlightPath` associated with a `Detector` will store the chain of `component_id` that link that detector to the source. Since `component_id`s do not change across copies. This should provide a mechanism to access the flight path despite any underlying copies/re-assignments happening below the `Node` level. `FlightPaths` only store the `component_ids` in an ordered fashion, so do not need to be updated in most scenarios.  Since the `InstrumentTree` gets recreated on each modification, we instead require that the `InstrumentTree` allows us to lookup `Component` via their ID.

**psuedo code**
```cpp
double DetectorComponent::l2(const InstrumentTree& instrument){
  return m_flightPath->l2(instrument);
}
```

`FlightPath` may calculate as follows.

```cpp
double FlightPath::l2(const InstrumentTree& instrument){

if(instrument == m_instrument){
   return m_flightPath; // This is the same instrument, so we can guarantee that nothing has moved.
}

// Walk the flight path and sum distances. Functional pseudo-code example. 
 auto from = m_detector;
 double distance = 0;
  for(auto & id :  m_chain){
    auto component = instrument->component(id);
    distance += component->distance(from);
    distance += component->length(); // Important. will usually default to zero, but will allow us to handle curvature in components. See requirements.
    from = component;
  }
 m_flightPath = distance;
 return m_flightPath;
}
```
## Performance Consideration ##

Detectors **WILL NOT BE STORED** in the `component_id` map therefore lookup times should be reasonable. For a simple instrument you may have simply 2 components in the map, a source and a sample. 