### PR TITLE
Fix errors found in benchmarks

### DIFF
--- a/cow_instrument/MoveCommand.cpp
+++ b/cow_instrument/MoveCommand.cpp
@@ -7,4 +7,6 @@ void MoveCommand::execute(Component &component) const {
   component.deltaPos(m_offset);
 }
 
-bool MoveCommand::isMetaDataCommand() const { return true; }
+bool MoveCommand::isMetaDataCommand() const { /*Moving is recursive*/
+  return false;
+}

--- a/cow_instrument/benchmark/InstrumentCopyBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentCopyBenchmark.cpp
@@ -10,99 +10,80 @@
 namespace {
 
 /*
- * Helper function to perform the benchmark at the specified deth in the
- * Instrument tree.
+ * Templated CopyFixture
 */
-void modifyNodeAtDepth(size_t depth, bool recordInstrumentCreation,
-                       benchmark::State &state) {
+template <size_t depth> class CopyFixture : public benchmark::Fixture {
 
-  // int counter = 0;
-  while (state.KeepRunning()) {
-    state.PauseTiming();
-    InstrumentTree instrument(std_instrument::construct_root_node(), 60000);
+public:
+  InstrumentTree m_instrument;
+  size_t m_nodeIndex;
+
+  CopyFixture()
+      : benchmark::Fixture(),
+        m_instrument(std_instrument::construct_root_node(), 60000),
+        m_nodeIndex(0) {
+
     // Walk down the tree to depth
-    size_t nodeIndex = 0;
-    const Node *node = &instrument.root();
+    const Node *node = &m_instrument.root();
     for (size_t i = 0; i < depth; ++i) {
-      nodeIndex = node->child(0);
-      node = instrument.nodeAt(i);
+      m_nodeIndex = node->child(0);
+      node = m_instrument.nodeAt(i);
     }
-    MoveCommand moveIt{V3D{1, 0, 0}};
-    state.ResumeTiming();
+  }
+};
 
+<<<<<<< Updated upstream
     // Then create the instrument around that node
     if (!recordInstrumentCreation) {
       state.PauseTiming();
     }
     // Then modify that node
     InstrumentTree copyInstrument = instrument.modify(nodeIndex, moveIt);
+=======
+using CopyAtRootLevel = CopyFixture<0>;
+using CopyAtTrolleyLevel = CopyFixture<1>;
+using CopyAtBankLevel = CopyFixture<2>;
+>>>>>>> Stashed changes
 
-    if (!recordInstrumentCreation) {
-      state.ResumeTiming();
-    }
-  }
-  state.SetItemsProcessed(state.iterations() * 1);
-}
-
-void BM_copy_unmodified(benchmark::State &state) {
+BENCHMARK_F(CopyAtRootLevel, BM_copy_unmodified)(benchmark::State &state) {
   while (state.KeepRunning()) {
-    state.PauseTiming();
-    InstrumentTree instrument(std_instrument::construct_root_node(), 60000);
-    state.ResumeTiming();
-
-    // Time an unmodified copy.
-    InstrumentTree copy = instrument;
+    // Then modify that node
+    auto copyInstrument = m_instrument;
   }
+  // For statistics. Mark the number of itertions
   state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_copy_unmodified);
 
-// ------------ Timings to include instrument tree creation ------------- //
-void
-BM_copy_move_root_with_instrument_creation_timing(benchmark::State &state) {
-  modifyNodeAtDepth(0 /*down to the root*/, true /*Time instrument creation*/,
-                    state);
+BENCHMARK_F(CopyAtRootLevel, BM_copy_move_root)(benchmark::State &state) {
+  MoveCommand moveIt{V3D{1, 0, 0}};
+  while (state.KeepRunning()) {
+    // Then modify that node
+    auto copyInstrument = m_instrument.modify(size_t(0), moveIt);
+  }
+  // For statistics. Mark the number of itertions
+  state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_copy_move_root_with_instrument_creation_timing);
 
-void BM_copy_move_one_trolley_with_instrument_creation_timing(
-    benchmark::State &state) {
-  modifyNodeAtDepth(1 /*down to the trolley*/,
-                    true /*Time instrument creation*/, state);
+BENCHMARK_F(CopyAtTrolleyLevel,
+            BM_copy_move_one_trolley)(benchmark::State &state) {
+  MoveCommand moveIt{V3D{1, 0, 0}};
+  while (state.KeepRunning()) {
+    // Then modify that node
+    auto copyInstrument = m_instrument.modify(1, moveIt);
+  }
+  // For statistics. Mark the number of itertions
+  state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_copy_move_one_trolley_with_instrument_creation_timing);
 
-void
-BM_copy_move_one_bank_with_instrument_creation_timing(benchmark::State &state) {
-  modifyNodeAtDepth(2 /*down to the bank*/, true /*Time instrument creation*/,
-                    state);
+BENCHMARK_F(CopyAtBankLevel, BM_copy_move_one_bank)(benchmark::State &state) {
+  MoveCommand moveIt{V3D{1, 0, 0}};
+  while (state.KeepRunning()) {
+    // Then modify that node
+    auto copyInstrument = m_instrument.modify(2, moveIt);
+  }
+  // For statistics. Mark the number of itertions
+  state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_copy_move_one_bank_with_instrument_creation_timing);
-// ------------ End Timings to include instrument tree creation ------------- //
-
-// ------------ Timings NOT to include instrument tree creation ------------- //
-void
-BM_copy_move_root_without_instrument_creation_timing(benchmark::State &state) {
-  modifyNodeAtDepth(0 /*down to the root*/, false /*Time instrument creation*/,
-                    state);
-}
-BENCHMARK(BM_copy_move_root_without_instrument_creation_timing);
-
-void BM_copy_move_one_trolley_without_instrument_creation_timing(
-    benchmark::State &state) {
-  modifyNodeAtDepth(1 /*down to the trolley*/,
-                    false /*Time instrument creation*/, state);
-}
-BENCHMARK(BM_copy_move_one_trolley_without_instrument_creation_timing);
-
-void BM_copy_move_one_bank_without_instrument_creation_timing(
-    benchmark::State &state) {
-  modifyNodeAtDepth(2 /*down to the bank*/, false /*Time instrument creation*/,
-                    state);
-}
-BENCHMARK(BM_copy_move_one_bank_without_instrument_creation_timing);
-// ------------ End Timings NOT to include instrument tree creation
-// ------------- //
 
 } // namespace
 

--- a/cow_instrument/benchmark/InstrumentCopyBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentCopyBenchmark.cpp
@@ -32,18 +32,9 @@ public:
   }
 };
 
-<<<<<<< Updated upstream
-    // Then create the instrument around that node
-    if (!recordInstrumentCreation) {
-      state.PauseTiming();
-    }
-    // Then modify that node
-    InstrumentTree copyInstrument = instrument.modify(nodeIndex, moveIt);
-=======
 using CopyAtRootLevel = CopyFixture<0>;
 using CopyAtTrolleyLevel = CopyFixture<1>;
 using CopyAtBankLevel = CopyFixture<2>;
->>>>>>> Stashed changes
 
 BENCHMARK_F(CopyAtRootLevel, BM_copy_unmodified)(benchmark::State &state) {
   while (state.KeepRunning()) {

--- a/cow_instrument/benchmark/InstrumentReadBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentReadBenchmark.cpp
@@ -24,35 +24,12 @@ void BM_InstrumentTreeConstruction(benchmark::State &state) {
 
     InstrumentTree instrument(std::move(flattenedNodeTree), 60000);
   }
+  state.SetItemsProcessed(state.iterations() * 1);
 }
 BENCHMARK(BM_InstrumentTreeConstruction);
 
 BENCHMARK_F(ReadFixture, BM_SngleAccessMetric)(benchmark::State &state) {
   while (state.KeepRunning()) {
-<<<<<<< Updated upstream
-    state.PauseTiming();
-    InstrumentTree instrument(std_instrument::construct_root_node(), 60000);
-    state.ResumeTiming();
-
-    size_t max = 100 * 100 * 6;
-    double pos_x = 0;
-    for (size_t i = 1; i < max; ++i) {
-      const auto &det = instrument.getDetector(i);
-      pos_x = det.getPos()[0];
-    }
-  }
-}
-BENCHMARK(BM_SingleAccessMetrics);
-
-void BM_SingleAccessMetricsStatic(benchmark::State &state) {
-  while (state.KeepRunning()) {
-    state.PauseTiming();
-    static InstrumentTree instrument(std_instrument::construct_root_node(),
-                                     60000);
-    state.ResumeTiming();
-=======
->>>>>>> Stashed changes
-
     size_t max = 100 * 100 * 6;
     double pos_x = 0;
     for (size_t i = 1; i < max; ++i) {
@@ -60,6 +37,7 @@ void BM_SingleAccessMetricsStatic(benchmark::State &state) {
       pos_x = det.getPos()[0];
     }
   }
+  state.SetItemsProcessed(state.iterations() * m_instrument.nDetectors());
 }
 
 } // namespace

--- a/cow_instrument/benchmark/InstrumentReadBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentReadBenchmark.cpp
@@ -7,6 +7,15 @@
 
 namespace {
 
+class ReadFixture : public benchmark::Fixture {
+public:
+  InstrumentTree m_instrument;
+
+  ReadFixture()
+      : benchmark::Fixture(),
+        m_instrument(std_instrument::construct_root_node(), 60000) {}
+};
+
 void BM_InstrumentTreeConstruction(benchmark::State &state) {
   while (state.KeepRunning()) {
     state.PauseTiming();
@@ -18,8 +27,9 @@ void BM_InstrumentTreeConstruction(benchmark::State &state) {
 }
 BENCHMARK(BM_InstrumentTreeConstruction);
 
-void BM_SingleAccessMetrics(benchmark::State &state) {
+BENCHMARK_F(ReadFixture, BM_SngleAccessMetric)(benchmark::State &state) {
   while (state.KeepRunning()) {
+<<<<<<< Updated upstream
     state.PauseTiming();
     InstrumentTree instrument(std_instrument::construct_root_node(), 60000);
     state.ResumeTiming();
@@ -40,16 +50,17 @@ void BM_SingleAccessMetricsStatic(benchmark::State &state) {
     static InstrumentTree instrument(std_instrument::construct_root_node(),
                                      60000);
     state.ResumeTiming();
+=======
+>>>>>>> Stashed changes
 
     size_t max = 100 * 100 * 6;
     double pos_x = 0;
     for (size_t i = 1; i < max; ++i) {
-      const auto &det = instrument.getDetector(i);
+      const auto &det = m_instrument.getDetector(i);
       pos_x = det.getPos()[0];
     }
   }
 }
-BENCHMARK(BM_SingleAccessMetricsStatic);
 
 } // namespace
 

--- a/cow_instrument/benchmark/StandardInstrument.cpp
+++ b/cow_instrument/benchmark/StandardInstrument.cpp
@@ -73,6 +73,7 @@ std::vector<Node> construct_root_node() {
 
   // Assemble flattened node node tree
   nodes[0].addChild(1);
+  nodes[0].addChild(6);
   nodes[1].addChild(2);
   nodes[1].addChild(3);
   nodes[1].addChild(4);


### PR DESCRIPTION
1) One logical error in measured code. Non recursion in Modify command.
2) Standard setup incorrect. Second trolley not added to route.
3) According to [gbench](https://github.com/google/benchmark/issues/179), use of `Pause` and `Resume` are deprecated.