### PR TITLE
Complex Beam Paths

### DIFF
--- a/cow_instrument/CMakeLists.txt
+++ b/cow_instrument/CMakeLists.txt
@@ -8,6 +8,7 @@ set ( SOURCE_FILES
                    MoveCommand.cpp
                    Node.cpp
                    NullComponent.cpp
+                   PathComponent.cpp
                    Spectrum.cpp
 )
 
@@ -23,13 +24,14 @@ set ( INCLUDE_FILES
                    FixedLengthVector.h
                    IdType.h
                    InstrumentTree.h
+                   IntToType.h
                    L2s.h
                    MaskFlags.h
                    MonitorFlags.h
                    MoveCommand.h
                    Node.h
                    NullComponent.h
-                   IntToType.h
+                   PathComponent.h
                    SpectrumInfo.h
                    Spectrum.h
                    V3D.h

--- a/cow_instrument/PathComponent.cpp
+++ b/cow_instrument/PathComponent.cpp
@@ -1,0 +1,18 @@
+#include "PathComponent.h"
+
+double PathComponent::length() const {
+  // Treat as a point. Zero length.
+  return 0;
+}
+
+V3D PathComponent::entryPoint() const {
+  // Treat as a point.
+  return this->getPos();
+}
+
+V3D PathComponent::exitPoint() const {
+  // Treat as a point.
+  return this->getPos();
+}
+
+PathComponent::~PathComponent() {}

--- a/cow_instrument/PathComponent.h
+++ b/cow_instrument/PathComponent.h
@@ -1,0 +1,29 @@
+#ifndef PATHCOMPONENT_H
+#define PATHCOMPONENT_H
+
+#include "Component.h"
+#include "V3D.h"
+
+/**
+ * Abstract type for a non-terminating component that can be used to form a
+ *Beam-Path.
+ *
+ * All Component subtypes save Detectors can be PathComponents
+ */
+class PathComponent : public Component {
+
+public:
+  /// Calculated internal scattering length
+  virtual double length() const;
+
+  /// Point at which neutrons enter the component
+  virtual V3D entryPoint() const;
+
+  /// Point at which neutrons exit the component
+  virtual V3D exitPoint() const;
+
+protected:
+  virtual ~PathComponent();
+};
+
+#endif

--- a/cow_instrument/testing/CMakeLists.txt
+++ b/cow_instrument/testing/CMakeLists.txt
@@ -39,6 +39,7 @@ set ( TEST_FILES
                  InstrumentTreeTest.cpp
                  MoveCommandTest.cpp
                  NodeTest.cpp
+                 PathComponentTest.cpp
                  SpectrumInfoTest.cpp
                  SpectrumTest.cpp
 )

--- a/cow_instrument/testing/DetectorComponentTest.cpp
+++ b/cow_instrument/testing/DetectorComponentTest.cpp
@@ -4,6 +4,7 @@
 #include "gmock/gmock.h"
 #include <array>
 #include "MockTypes.h"
+#include "PathComponent.h"
 
 using namespace testing;
 
@@ -56,6 +57,13 @@ TEST(detector_component_test, test_copy) {
   EXPECT_EQ(det.detectorId(), copy.detectorId());
   EXPECT_EQ(det.componentId(), copy.componentId());
   EXPECT_EQ(det.getPos(), copy.getPos());
+}
+
+TEST(detector_component_test, test_not_path_component) {
+  DetectorComponent detector(ComponentIdType{1}, DetectorIdType{1},
+                             V3D{1, 1, 1});
+  EXPECT_EQ(dynamic_cast<PathComponent *>(&detector), nullptr)
+      << "DetectorComponent should not have public base PathComponent";
 }
 
 } // namespace

--- a/cow_instrument/testing/PathComponentTest.cpp
+++ b/cow_instrument/testing/PathComponentTest.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include <string>
+#include "PathComponent.h"
+#include "Detector.h"
+#include "V3D.h"
+
+namespace {
+
+/**
+ * FakePathComponent class for testing PathComponent.
+ */
+class FakePathComponent : public PathComponent {
+private:
+  V3D m_position;
+
+  // Component interface
+public:
+  FakePathComponent(const V3D &position) : m_position(position) {}
+  V3D getPos() const { return m_position; }
+  void deltaPos(const V3D &){};
+  Component *clone() const { return new FakePathComponent{m_position}; };
+  bool equals(const Component &other) const { return false; };
+  void registerContents(std::vector<const Detector *> &) const {}
+  ComponentIdType componentId() const { return ComponentIdType{1}; }
+  std::string name() const { return ""; };
+};
+
+TEST(path_component_test, test_default_length) {
+
+  V3D position{1, 1, 1};
+  FakePathComponent pathComponent(position);
+  EXPECT_EQ(pathComponent.length(), 0);
+}
+
+TEST(path_component_test, test_default_entryPoint) {
+
+  V3D position{1, 1, 1};
+  FakePathComponent pathComponent(position);
+  EXPECT_EQ(pathComponent.entryPoint(), position);
+}
+
+TEST(path_component_test, test_default_exitPoint) {
+
+  V3D position{1, 1, 1};
+  FakePathComponent pathComponent(position);
+  EXPECT_EQ(pathComponent.exitPoint(), position);
+}
+}


### PR DESCRIPTION
Fixes #5. Solve complex-beam problem. Ensure that performance does not degrade with new addition.

Work in progress. Do not merge.