### PR TITLE
Write then read. Just like Mantid updates.

### DIFF
--- a/cow_instrument/benchmark/InstrumentWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentWriteRotateBenchmark.cpp
@@ -10,23 +10,40 @@ namespace {
 class WriteRotateFixture : public StandardInstrumentFixture {
 
 public:
-  void rotateOnNode(size_t nodeIndex, benchmark::State &state) {
+  void rotateOnNode(size_t nodeIndex, bool read, benchmark::State &state) {
     RotateCommand rotateIt{Eigen::Vector3d{0, 0, 1}, M_PI};
     while (state.KeepRunning()) {
       // Then modify that node
       m_instrument.modify(nodeIndex, rotateIt);
+
+      // If we want to compare reads too.
+      if (read) {
+        Eigen::Vector3d pos;
+        for (size_t i = 0; i < m_instrument.nDetectors(); ++i) {
+          benchmark::DoNotOptimize(pos += m_instrument.getDetector(i).getPos());
+        }
+      }
     }
     // For statistics. Mark the number of itertions
     state.SetItemsProcessed(state.iterations() * 1);
   }
 
-  void rotateOnNodeWithCopy(size_t nodeIndex, benchmark::State &state) {
+  void rotateOnNodeWithCopy(size_t nodeIndex, bool read,
+                            benchmark::State &state) {
     RotateCommand rotateIt{Eigen::Vector3d{0, 0, 1}, M_PI};
     while (state.KeepRunning()) {
       // increase reference count on components
       auto temp = m_instrument;
       // Then modify that node
       temp.modify(nodeIndex, rotateIt);
+
+      // If we want to compare reads too.
+      if (read) {
+        Eigen::Vector3d pos;
+        for (size_t i = 0; i < temp.nDetectors(); ++i) {
+          benchmark::DoNotOptimize(pos += temp.getDetector(i).getPos());
+        }
+      }
     }
     // For statistics. Mark the number of itertions
     state.SetItemsProcessed(state.iterations() * 1);
@@ -34,30 +51,40 @@ public:
 };
 
 BENCHMARK_F(WriteRotateFixture, BM_cow_rotate_root)(benchmark::State &state) {
-  this->rotateOnNodeWithCopy(0, state);
+  this->rotateOnNodeWithCopy(0, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteRotateFixture,
             BM_cow_rotate_one_trolley)(benchmark::State &state) {
-  this->rotateOnNodeWithCopy(1, state);
+  this->rotateOnNodeWithCopy(1, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteRotateFixture,
             BM_cow_rotate_one_bank)(benchmark::State &state) {
-  this->rotateOnNodeWithCopy(2, state);
+  this->rotateOnNodeWithCopy(2, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteRotateFixture, BM_rotate_root)(benchmark::State &state) {
-  this->rotateOnNode(0, state);
+  this->rotateOnNode(0, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteRotateFixture,
             BM_rotate_one_trolley)(benchmark::State &state) {
-  this->rotateOnNode(1, state);
+  this->rotateOnNode(1, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteRotateFixture, BM_rotate_one_bank)(benchmark::State &state) {
-  this->rotateOnNode(2, state);
+  this->rotateOnNode(2, false /*no read metric*/, state);
+}
+
+BENCHMARK_F(WriteRotateFixture,
+            BM_cow_rotate_one_bank_with_pos_read)(benchmark::State &state) {
+  this->rotateOnNodeWithCopy(2, true /*with read metric*/, state);
+}
+
+BENCHMARK_F(WriteRotateFixture,
+            BM_rotate_one_bank_with_pos_read)(benchmark::State &state) {
+  this->rotateOnNode(2, true /*with read metric*/, state);
 }
 
 void BM_rotation_one_bank_math(benchmark::State &state) {

--- a/cow_instrument/benchmark/InstrumentWriteTranslateBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentWriteTranslateBenchmark.cpp
@@ -12,23 +12,40 @@ namespace {
 class WriteTranslateFixture : public StandardInstrumentFixture {
 
 public:
-  void translateOnNode(size_t nodeIndex, benchmark::State &state) {
+  void translateOnNode(size_t nodeIndex, bool read, benchmark::State &state) {
     MoveCommand moveIt{Eigen::Vector3d{1, 0, 0}};
     while (state.KeepRunning()) {
       // Then modify that node
       m_instrument.modify(nodeIndex, moveIt);
+
+      // If we want to compare reads too.
+      if (read) {
+        Eigen::Vector3d pos;
+        for (size_t i = 0; i < m_instrument.nDetectors(); ++i) {
+          benchmark::DoNotOptimize(pos += m_instrument.getDetector(i).getPos());
+        }
+      }
     }
     // For statistics. Mark the number of itertions
     state.SetItemsProcessed(state.iterations() * 1);
   }
 
-  void translateOnNodeWithCopy(size_t nodeIndex, benchmark::State &state) {
+  void translateOnNodeWithCopy(size_t nodeIndex, bool read,
+                               benchmark::State &state) {
     MoveCommand moveIt{Eigen::Vector3d{1, 0, 0}};
     while (state.KeepRunning()) {
-          // increase reference count on components
+      // increase reference count on components
       auto temp = m_instrument;
       // Then modify that node
       temp.modify(nodeIndex, moveIt);
+
+      // If we want to compare reads too.
+      if (read) {
+        Eigen::Vector3d pos;
+        for (size_t i = 0; i < temp.nDetectors(); ++i) {
+          benchmark::DoNotOptimize(pos += temp.getDetector(i).getPos());
+        }
+      }
     }
     // For statistics. Mark the number of itertions
     state.SetItemsProcessed(state.iterations() * 1);
@@ -37,31 +54,41 @@ public:
 
 BENCHMARK_F(WriteTranslateFixture,
             BM_cow_translate_root)(benchmark::State &state) {
-  this->translateOnNodeWithCopy(0, state);
+  this->translateOnNodeWithCopy(0, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteTranslateFixture,
             BM_cow_translate_one_trolley)(benchmark::State &state) {
-  this->translateOnNodeWithCopy(1, state);
+  this->translateOnNodeWithCopy(1, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteTranslateFixture,
             BM_cow_translate_one_bank)(benchmark::State &state) {
-  this->translateOnNodeWithCopy(2, state);
+  this->translateOnNodeWithCopy(2, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteTranslateFixture, BM_translate_root)(benchmark::State &state) {
-  this->translateOnNode(0, state);
+  this->translateOnNode(0, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteTranslateFixture,
             BM_translate_one_trolley)(benchmark::State &state) {
-  this->translateOnNode(1, state);
+  this->translateOnNode(1, false /*no read metric*/, state);
 }
 
 BENCHMARK_F(WriteTranslateFixture,
             BM_translate_one_bank)(benchmark::State &state) {
-  this->translateOnNode(2, state);
+  this->translateOnNode(2, false /*no read metric*/, state);
+}
+
+BENCHMARK_F(WriteTranslateFixture,
+            BM_cow_translate_one_bank_with_pos_read)(benchmark::State &state) {
+  this->translateOnNodeWithCopy(2, true /*with read metric*/, state);
+}
+
+BENCHMARK_F(WriteTranslateFixture,
+            BM_translate_one_bank_with_pos_read)(benchmark::State &state) {
+  this->translateOnNode(2, true /*with read metric*/, state);
 }
 
 } // namespace


### PR DESCRIPTION
I'm updating the Mantid performance tests so that what Mantid does can be measured against the prototype. A common scenario is the write then read. i.e. move or rotate something then read the position of it. In data reduction you always perform a read after a write so it seems sensible to add a benchmark for this. Also Mantids write performance is misleading because it's very low-overhead, but offloads all the poor performance to the read. So a comparison that measures a write alone is not as useful. 

This is meticulousness related to #31 equivalent benchmarks will be added to Mantid.