### PR TITLE
Reduce benchmark noise

### DIFF
--- a/cow_instrument/benchmark/CMakeLists.txt
+++ b/cow_instrument/benchmark/CMakeLists.txt
@@ -35,6 +35,7 @@ set ( BENCH_FILES_SRC
 )
 
 set ( BENCH_FILES_H
+                 StandardBenchmark.h
                  StandardInstrument.h
 )
 

--- a/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
@@ -53,7 +53,11 @@ BENCHMARK_F(ComponentInfoWriteRotateFixture,
   this->rotateOnComponent(2, true /*with read metric*/, state);
 }
 
-void BM_rotation_one_bank_math(benchmark::State &state) {
+// Just gets us the execution policy
+class RotationBenchmark : public StandardBenchmark<RotationBenchmark> {};
+
+BENCHMARK_F(RotationBenchmark,
+            BM_rotation_one_bank_math)(benchmark::State &state) {
   // Check the rotation math independenly of other implementation details.
 
   // One bank has 100 * 100 detectors
@@ -80,6 +84,5 @@ void BM_rotation_one_bank_math(benchmark::State &state) {
   // compare against a single bank.
   state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_rotation_one_bank_math);
 
 } // namespace

--- a/cow_instrument/benchmark/InstrumentConstructionBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentConstructionBenchmark.cpp
@@ -1,18 +1,24 @@
+#include "StandardBenchmark.h"
 #include "StandardInstrument.h"
 #include <benchmark/benchmark_api.h>
 
 namespace {
 
-void BM_instrument_component_tree_construction(benchmark::State &state) {
+class InstrumentConstructionBenchmark
+    : public StandardBenchmark<InstrumentConstructionBenchmark> {};
+
+BENCHMARK_F(InstrumentConstructionBenchmark,
+            BM_instrument_component_tree_construction)(
+    benchmark::State &state) {
 
   while (state.KeepRunning()) {
     benchmark::DoNotOptimize(std_instrument::construct_root_component());
   }
   state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_instrument_component_tree_construction);
 
-void BM_instrument_tree_copy_construction(benchmark::State &state) {
+BENCHMARK_F(InstrumentConstructionBenchmark,
+            BM_instrument_tree_copy_construction)(benchmark::State &state) {
   size_t nDetectors = 0;
   while (state.KeepRunning()) {
     auto tree = std_instrument::construct_root_component();
@@ -21,5 +27,4 @@ void BM_instrument_tree_copy_construction(benchmark::State &state) {
   }
   state.SetItemsProcessed(state.iterations() * 1);
 }
-BENCHMARK(BM_instrument_tree_copy_construction);
 }

--- a/cow_instrument/benchmark/InstrumentSerializationBenchmark.cpp
+++ b/cow_instrument/benchmark/InstrumentSerializationBenchmark.cpp
@@ -1,6 +1,7 @@
 #include "StandardInstrument.h"
 #include "FlatTree.h"
 #include "FlatTreeMapper.h"
+#include "StandardBenchmark.h"
 #include <benchmark/benchmark_api.h>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/cow_instrument/benchmark/SpectrumInfoBenchmark.cpp
+++ b/cow_instrument/benchmark/SpectrumInfoBenchmark.cpp
@@ -1,19 +1,20 @@
 #include "benchmark/benchmark_api.h"
 #include "FlatTree.h"
 #include "SpectrumInfo.h"
+#include "StandardBenchmark.h"
 #include "StandardInstrument.h"
 #include "SourceSampleDetectorPathFactory.h"
 #include <memory.h>
 
 namespace {
 
-class SpectrumInfoFixture : public benchmark::Fixture {
+class SpectrumInfoFixture : public StandardBenchmark<SpectrumInfoFixture> {
 
 public:
   SpectrumInfo<FlatTree> m_spectrumInfo;
 
   SpectrumInfoFixture()
-      : benchmark::Fixture(),
+      : StandardBenchmark<SpectrumInfoFixture>(),
         m_spectrumInfo(DetectorInfo<FlatTree>(
             std::make_shared<FlatTree>(
                 std_instrument::construct_root_component()),

--- a/cow_instrument/benchmark/StandardBenchmark.h
+++ b/cow_instrument/benchmark/StandardBenchmark.h
@@ -1,0 +1,23 @@
+#ifndef STANDARDBENCHMARK_H
+#define STANDARDBENCHMARK_H
+
+#include <benchmark/benchmark_api.h>
+
+/**
+ * CRTP For providing a global benchmark execution policy set.
+ */
+template <typename T> class StandardBenchmark : public benchmark::Fixture {
+public:
+  StandardBenchmark();
+};
+
+template <typename T>
+StandardBenchmark<T>::StandardBenchmark()
+    : benchmark::Fixture() {
+  // Every benchmark repeated 6 times.
+  Repetitions(6);
+  // Only report the mean and standard deviations
+  ReportAggregatesOnly(true);
+}
+
+#endif

--- a/cow_instrument/benchmark/StandardInstrument.cpp
+++ b/cow_instrument/benchmark/StandardInstrument.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<Component> construct_root_component() {
 }
 
 StandardInstrumentFixture::StandardInstrumentFixture()
-    : benchmark::Fixture(),
+    : StandardBenchmark<StandardInstrumentFixture>(),
       m_instrument(std_instrument::construct_root_component()),
       m_componentInfo(std::make_shared<FlatTree>(
           std_instrument::construct_root_component())),

--- a/cow_instrument/benchmark/StandardInstrument.h
+++ b/cow_instrument/benchmark/StandardInstrument.h
@@ -4,6 +4,7 @@
 #include "FlatTree.h"
 #include "ComponentInfo.h"
 #include "DetectorInfo.h"
+#include "StandardBenchmark.h"
 #include <vector>
 #include <benchmark/benchmark_api.h>
 
@@ -15,7 +16,8 @@ std::shared_ptr<Component> construct_root_component();
 /*
  Create a standard instrument fixture.
  */
-class StandardInstrumentFixture : public benchmark::Fixture {
+class StandardInstrumentFixture
+    : public StandardBenchmark<StandardInstrumentFixture> {
 
 public:
   FlatTree m_instrument;


### PR DESCRIPTION
google benchmark offers some better features for providing information on test variance as well as statistical averaging of results. 

The changes here introduce a "Policy" for all benchmarks.

* Each benchmark is executed 6 times (not the same as benchmark "iterations")
* The mean and standard deviation only are reported.