### PR TITLE
Pre-scanning simplifications

### DIFF
--- a/cow_instrument/CMakeLists.txt
+++ b/cow_instrument/CMakeLists.txt
@@ -54,6 +54,7 @@ set ( INCLUDE_FILES
                    ParabolicGuide.h
                    Path.h
                    PathComponent.h
+                   PathComponentInfo.h
                    PathFactory.h
                    PointPathComponent.h
                    PointSample.h

--- a/cow_instrument/Component.h
+++ b/cow_instrument/Component.h
@@ -23,9 +23,8 @@ public:
   virtual std::string name() const = 0;
   virtual bool accept(class ComponentVisitor *visitor) const = 0;
 
-  virtual Eigen::Vector3d getPos() const = 0; // TODO. Remove to avoid mistakes
-  virtual Eigen::Quaterniond
-  getRotation() const = 0; // TODO. Remove to avoid mistakes
+  virtual Eigen::Vector3d getPos() const = 0;
+  virtual Eigen::Quaterniond getRotation() const = 0;
 };
 
 #endif

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -194,6 +194,9 @@ void ComponentInfo<InstTree>::rotate(size_t componentIndex,
       detectorsToRotate; // Cache of detector indexes which will be rotated.
   std::vector<size_t> pathComponentsToRotate; // Cache of path component indexes
                                               // which will be rotated
+
+  detectorsToRotate.reserve(componentIndexes.size());
+  pathComponentsToRotate.reserve(componentIndexes.size());
   for (auto &compIndex : componentIndexes) {
     auto detIndex = m_componentToDetectorIndex[compIndex];
     if (detIndex >= 0) {

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -159,6 +159,9 @@ void ComponentInfo<InstTree>::move(size_t componentIndex,
       detectorsToMove; // Cache of detector indexes which will be moved.
   std::vector<size_t> pathComponentsToMove; // Cache of path component indexes
                                             // which will be moved
+
+  detectorsToMove.reserve(componentIndexes.size());
+  pathComponentsToMove.reserve(componentIndexes.size());
   for (auto &compIndex : componentIndexes) {
     auto detIndex = m_componentToDetectorIndex[compIndex];
     if (detIndex >= 0) {

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -141,34 +141,30 @@ Eigen::Vector3d ComponentInfo<InstTree>::position(size_t componentIndex) const {
   auto detIndex = m_componentToDetectorIndex[componentIndex];
   if (detIndex >= 0) {
     return m_detectorInfo->position(detIndex);
-  } else {
-
-    auto pathIndex = m_componentToPathIndex[componentIndex];
-    if (pathIndex >= 0) {
-      return m_detectorInfo->pathComponentInfo().position(pathIndex);
-    } else {
-      auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
-      return (*m_positions)[branchNodeIndex];
-    }
   }
+
+  auto pathIndex = m_componentToPathIndex[componentIndex];
+  if (pathIndex >= 0) {
+    return m_detectorInfo->pathComponentInfo().position(pathIndex);
+  }
+  auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
+  return (*m_positions)[branchNodeIndex];
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
 ComponentInfo<InstTree>::rotation(size_t componentIndex) const {
-    auto detIndex = m_componentToDetectorIndex[componentIndex];
-    if (detIndex >= 0) {
-      return m_detectorInfo->rotation(detIndex);
-    } else {
+  auto detIndex = m_componentToDetectorIndex[componentIndex];
+  if (detIndex >= 0) {
+    return m_detectorInfo->rotation(detIndex);
+  }
 
-      auto pathIndex = m_componentToPathIndex[componentIndex];
-      if (pathIndex >= 0) {
-        return m_detectorInfo->pathComponentInfo().rotation(pathIndex);
-      } else {
-        auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
-        return (*m_rotations)[branchNodeIndex];
-      }
-    }
+  auto pathIndex = m_componentToPathIndex[componentIndex];
+  if (pathIndex >= 0) {
+    return m_detectorInfo->pathComponentInfo().rotation(pathIndex);
+  }
+  auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
+  return (*m_rotations)[branchNodeIndex];
 }
 
 template <typename InstTree>

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -20,16 +20,17 @@
  */
 template <typename InstTree> class ComponentInfo {
 public:
-  explicit ComponentInfo(std::shared_ptr<InstTree> &&instrumentTree);
-  explicit ComponentInfo(std::shared_ptr<InstTree> &instrumentTree);
-
   explicit ComponentInfo(
       std::shared_ptr<DetectorInfo<InstTree>> &&detectorInfo);
   explicit ComponentInfo(std::shared_ptr<DetectorInfo<InstTree>> &detectorInfo);
 
-  Eigen::Vector3d position(size_t componentIndex) const;
+  Eigen::Vector3d positionOfDetector(size_t componentIndex) const;
 
-  Eigen::Quaterniond rotation(size_t componentIndex) const;
+  Eigen::Vector3d positionOfPathComponent(size_t componentIndex) const;
+
+  Eigen::Quaterniond rotationOfDetector(size_t componentIndex) const;
+
+  Eigen::Quaterniond rotationOfPathComponent(size_t componentIndex) const;
 
   size_t size() const;
 
@@ -42,65 +43,25 @@ public:
   void rotate(size_t componentIndex, const Eigen::Vector3d &axis,
               const double &theta, const Eigen::Vector3d &center);
 
-  void move2(size_t componentIndex, const Eigen::Vector3d &offset);
-
-  void rotate2(size_t componentIndex, const Eigen::Vector3d &axis,
-               const double &theta, const Eigen::Vector3d &center);
-
 private:
   /// Detector info
-  std::shared_ptr<const DetectorInfo<InstTree>> m_detectorInfo;
-  /// Instrument tree.
-  std::shared_ptr<const InstTree> m_instrumentTree; // Legacy. Remove
+  std::shared_ptr<DetectorInfo<InstTree>> m_detectorInfo;
   /// Instrument tree
-  const InstTree &m_instrumentTree2;
-  /// All positions indexed by component index. Owned by ComponentInfo.
-  CowPtr<std::vector<Eigen::Vector3d>> m_positions;
-  /// All rotations indexed by component index. Owned by ComponentInfo.
-  CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
-  // TODO shapes and parameters would also be stored here
+  const InstTree &m_instrumentTree;
   /// Inverted map to get detector indexes from component indexes
   std::vector<int64_t> m_componentToDetectorIndex;
   /// Inverted map to get path component indexes indexes from component indexes
   std::vector<int64_t> m_componentToPathIndex;
-
   void makeInvertedMaps();
 };
 
 template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
-    std::shared_ptr<InstTree> &instrumentTree)
-    : m_instrumentTree(instrumentTree), m_instrumentTree2(*m_instrumentTree),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree->startPositions())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree->startRotations()))
-
-{}
-
-template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(
-    std::shared_ptr<InstTree> &&instrumentTree)
-    : m_instrumentTree(std::forward<std::shared_ptr<InstTree>>(instrumentTree)),
-      m_instrumentTree2(*m_instrumentTree),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree->startPositions())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree->startRotations()))
-
-{}
-
-template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(
     std::shared_ptr<DetectorInfo<InstTree>> &detectorInfo)
     : m_detectorInfo(detectorInfo),
-      m_instrumentTree2(m_detectorInfo->const_instrumentTree()),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree2.startPositions())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree2.startRotations())),
-      m_componentToDetectorIndex(m_instrumentTree2.componentSize(), -1),
-      m_componentToPathIndex(m_instrumentTree2.componentSize(), -1) {
+      m_instrumentTree(m_detectorInfo->const_instrumentTree()),
+      m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
+      m_componentToPathIndex(m_instrumentTree.componentSize(), -1) {
 
   makeInvertedMaps();
 }
@@ -109,21 +70,17 @@ template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
     std::shared_ptr<DetectorInfo<InstTree>> &&detectorInfo)
     : m_detectorInfo(std::move(detectorInfo)),
-      m_instrumentTree2(m_detectorInfo->const_instrumentTree()),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree2.startPositions())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree2.startRotations())),
-      m_componentToDetectorIndex(m_instrumentTree2.componentSize(), -1),
-      m_componentToPathIndex(m_instrumentTree2.componentSize(), -1) {
+      m_instrumentTree(m_detectorInfo->const_instrumentTree()),
+      m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
+      m_componentToPathIndex(m_instrumentTree.componentSize(), -1) {
   makeInvertedMaps();
 }
 
 template <typename InstTree> void ComponentInfo<InstTree>::makeInvertedMaps() {
 
   // Invert the map.
-  auto detToComponent = m_instrumentTree2.detectorComponentIndexes();
-  auto pathToComponent = m_instrumentTree2.pathComponentIndexes();
+  auto detToComponent = m_instrumentTree.detectorComponentIndexes();
+  auto pathToComponent = m_instrumentTree.pathComponentIndexes();
   for (size_t i = 0; i < detToComponent.size(); ++i) {
     m_componentToDetectorIndex[detToComponent[i]] = i;
   }
@@ -132,46 +89,91 @@ template <typename InstTree> void ComponentInfo<InstTree>::makeInvertedMaps() {
   }
 }
 
+/**
+ * Preferred mechanism would be to go through DetectorInfo.
+ */
 template <typename InstTree>
-Eigen::Vector3d ComponentInfo<InstTree>::position(size_t componentIndex) const {
-  return (*m_positions)[componentIndex];
+Eigen::Vector3d
+ComponentInfo<InstTree>::positionOfDetector(size_t componentIndex) const {
+
+  auto detIndex = m_componentToDetectorIndex[componentIndex];
+  if (detIndex >= 0) {
+    return m_detectorInfo->positionDetector(detIndex);
+  } else {
+    throw std::invalid_argument(
+        "No detector with corresponding component index " +
+        std::to_string(componentIndex));
+  }
 }
 
+/**
+ * Preferred mechanism would be to go through DetectorInfo.
+ */
+template <typename InstTree>
+Eigen::Vector3d
+ComponentInfo<InstTree>::positionOfPathComponent(size_t componentIndex) const {
+
+  auto pathIndex = m_componentToPathIndex[componentIndex];
+  if (pathIndex >= 0) {
+    return m_detectorInfo->pathComponentInfo().position(pathIndex);
+  } else {
+    throw std::invalid_argument(
+        "No path component with corresponding component index " +
+        std::to_string(componentIndex));
+  }
+}
+
+/**
+ * Preferred mechanism would be to go through DetectorInfo.
+ */
 template <typename InstTree>
 Eigen::Quaterniond
-ComponentInfo<InstTree>::rotation(size_t componentIndex) const {
-  return (*m_rotations)[componentIndex];
+ComponentInfo<InstTree>::rotationOfDetector(size_t componentIndex) const {
+
+  auto detIndex = m_componentToPathIndex[componentIndex];
+  if (detIndex >= 0) {
+    return m_detectorInfo->rotationDetector(detIndex);
+  } else {
+    throw std::invalid_argument(
+        "No detector with corresponding component index " +
+        std::to_string(componentIndex));
+  }
+}
+
+/**
+ * Preferred mechanism would be to go through DetectorInfo.
+ */
+template <typename InstTree>
+Eigen::Quaterniond
+ComponentInfo<InstTree>::rotationOfPathComponent(size_t componentIndex) const {
+
+  auto pathIndex = m_componentToPathIndex[componentIndex];
+  if (pathIndex >= 0) {
+    return m_detectorInfo->pathComponentInfo().rotation(pathIndex);
+  } else {
+    throw std::invalid_argument(
+        "No path component with corresponding component index " +
+        std::to_string(componentIndex));
+  }
 }
 
 template <typename InstTree>
 size_t ComponentInfo<InstTree>::componentSize() const {
-  return m_instrumentTree->componentSize();
+  return m_instrumentTree.componentSize();
 }
 
 template <typename InstTree>
 const InstTree &ComponentInfo<InstTree>::const_instrumentTree() const {
-  return *m_instrumentTree;
+  return m_instrumentTree;
 }
 
 template <typename InstTree>
 void ComponentInfo<InstTree>::move(size_t componentIndex,
                                    const Eigen::Vector3d &offset) {
 
-  const std::vector<size_t> indexes =
-      m_instrumentTree->subTreeIndexes(componentIndex);
-  for (auto &index : indexes) {
-    (*m_positions)[index] += offset;
-    // TODO m_entry and m_exit points should also be translated here!
-  }
-}
-
-template <typename InstTree>
-void ComponentInfo<InstTree>::move2(size_t componentIndex,
-                                    const Eigen::Vector3d &offset) {
-
   // All "connected" component indexes
   const std::vector<size_t> componentIndexes =
-      m_instrumentTree->subTreeIndexes(componentIndex);
+      m_instrumentTree.subTreeIndexes(componentIndex);
 
   std::vector<size_t>
       detectorsToMove; // Cache of detector indexes which will be moved.
@@ -187,22 +189,23 @@ void ComponentInfo<InstTree>::move2(size_t componentIndex,
     if (pathIndex >= 0) {
       pathComponentsToMove.push_back(pathIndex);
     }
+
+    // Anything else in the subtree is ignored. Correctly.
   }
 
   m_detectorInfo->moveDetectors(detectorsToMove, offset);
-  m_detectorInfo->pathComponentInfo().movePathComponents(pathComponentsToMove,
-                                                         offset);
+  m_detectorInfo->movePathComponents(pathComponentsToMove, offset);
 }
 
 template <typename InstTree>
-void ComponentInfo<InstTree>::rotate2(size_t componentIndex,
-                                      const Eigen::Vector3d &axis,
-                                      const double &theta,
-                                      const Eigen::Vector3d &center) {
+void ComponentInfo<InstTree>::rotate(size_t componentIndex,
+                                     const Eigen::Vector3d &axis,
+                                     const double &theta,
+                                     const Eigen::Vector3d &center) {
 
   // All "connected" component indexes
   const std::vector<size_t> componentIndexes =
-      m_instrumentTree->subTreeIndexes(componentIndex);
+      m_instrumentTree.subTreeIndexes(componentIndex);
 
   std::vector<size_t>
       detectorsToRotate; // Cache of detector indexes which will be rotated.
@@ -218,32 +221,14 @@ void ComponentInfo<InstTree>::rotate2(size_t componentIndex,
     if (pathIndex >= 0) {
       pathComponentsToRotate.push_back(pathIndex);
     }
+
+    // Anything else in the subtree is ignored. Correctly.
     }
 
   m_detectorInfo->rotateDetectors(detectorsToRotate, axis, theta, center);
-  m_detectorInfo->pathComponentInfo().rotatePathComponents(
-      pathComponentsToRotate, axis, theta, center);
+  m_detectorInfo->rotatePathComponents(pathComponentsToRotate, axis, theta,
+                                       center);
 }
 
-template <typename InstTree>
-void ComponentInfo<InstTree>::rotate(size_t componentIndex,
-                                     const Eigen::Vector3d &axis,
-                                     const double &theta,
-                                     const Eigen::Vector3d &center) {
-
-  using namespace Eigen;
-  const auto transform =
-      Translation3d(center) * AngleAxisd(theta, axis) * Translation3d(-center);
-  const auto rotation = transform.rotation();
-
-  const std::vector<size_t> indexes =
-      m_instrumentTree->subTreeIndexes(componentIndex);
-
-  for (auto &index : indexes) {
-    (*m_positions)[index] = transform * (*m_positions)[index];
-    (*m_rotations)[index] = rotation * (*m_rotations)[index];
-    // TODO m_entry and m_exit points should also be translated here!
-  }
-}
 
 #endif

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -22,9 +22,8 @@
  */
 template <typename InstTree> class ComponentInfo {
 public:
-  explicit ComponentInfo(
-      std::shared_ptr<DetectorInfo<InstTree>> &&detectorInfo);
-  explicit ComponentInfo(std::shared_ptr<DetectorInfo<InstTree>> &detectorInfo);
+  explicit ComponentInfo(const DetectorInfo<InstTree> &detectorInfo);
+  explicit ComponentInfo(const DetectorInfo<InstTree> &&detectorInfo);
 
   Eigen::Vector3d position(size_t componentIndex) const;
 
@@ -47,7 +46,7 @@ private:
   /// Make maps with component index as key.
   void makeInvertedMaps();
   /// Detector info
-  std::shared_ptr<DetectorInfo<InstTree>> m_detectorInfo;
+  DetectorInfo<InstTree> m_detectorInfo;
   /// Instrument tree
   const InstTree &m_instrumentTree;
   /// Inverted map to get detector indexes from component indexes
@@ -65,10 +64,9 @@ private:
 };
 
 template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(
-    std::shared_ptr<DetectorInfo<InstTree>> &detectorInfo)
+ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &detectorInfo)
     : m_detectorInfo(detectorInfo),
-      m_instrumentTree(m_detectorInfo->const_instrumentTree()),
+      m_instrumentTree(m_detectorInfo.const_instrumentTree()),
       m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
       m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
       m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1),
@@ -85,10 +83,9 @@ ComponentInfo<InstTree>::ComponentInfo(
 }
 
 template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(
-    std::shared_ptr<DetectorInfo<InstTree>> &&detectorInfo)
+ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &&detectorInfo)
     : m_detectorInfo(std::move(detectorInfo)),
-      m_instrumentTree(m_detectorInfo->const_instrumentTree()),
+      m_instrumentTree(m_detectorInfo.const_instrumentTree()),
       m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
       m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
       m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1),
@@ -97,10 +94,13 @@ ComponentInfo<InstTree>::ComponentInfo(
       m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
           m_instrumentTree.nBranchNodeComponents())),
       m_branchNodeComponentIndexes(std::make_shared<std::vector<size_t>>(
-          m_instrumentTree.branchNodeComponentIndexes())) {
+          m_instrumentTree.branchNodeComponentIndexes()))
+
+{
 
   init();
 }
+
 
 template <typename InstrTree> void ComponentInfo<InstrTree>::init() {
   // TODO. Do this without copying everything!
@@ -140,12 +140,12 @@ Eigen::Vector3d ComponentInfo<InstTree>::position(size_t componentIndex) const {
 
   auto detIndex = m_componentToDetectorIndex[componentIndex];
   if (detIndex >= 0) {
-    return m_detectorInfo->position(detIndex);
+    return m_detectorInfo.position(detIndex);
   }
 
   auto pathIndex = m_componentToPathIndex[componentIndex];
   if (pathIndex >= 0) {
-    return m_detectorInfo->pathComponentInfo().position(pathIndex);
+    return m_detectorInfo.pathComponentInfo().position(pathIndex);
   }
   auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
   return (*m_positions)[branchNodeIndex];
@@ -156,12 +156,12 @@ Eigen::Quaterniond
 ComponentInfo<InstTree>::rotation(size_t componentIndex) const {
   auto detIndex = m_componentToDetectorIndex[componentIndex];
   if (detIndex >= 0) {
-    return m_detectorInfo->rotation(detIndex);
+    return m_detectorInfo.rotation(detIndex);
   }
 
   auto pathIndex = m_componentToPathIndex[componentIndex];
   if (pathIndex >= 0) {
-    return m_detectorInfo->pathComponentInfo().rotation(pathIndex);
+    return m_detectorInfo.pathComponentInfo().rotation(pathIndex);
   }
   auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
   return (*m_rotations)[branchNodeIndex];
@@ -209,8 +209,8 @@ void ComponentInfo<InstTree>::move(size_t componentIndex,
     }
   }
 
-  m_detectorInfo->moveDetectors(detectorsToMove, offset);
-  m_detectorInfo->movePathComponents(pathComponentsToMove, offset);
+  m_detectorInfo.moveDetectors(detectorsToMove, offset);
+  m_detectorInfo.movePathComponents(pathComponentsToMove, offset);
 }
 
 template <typename InstTree>
@@ -255,8 +255,8 @@ void ComponentInfo<InstTree>::rotate(size_t componentIndex,
     }
   }
 
-  m_detectorInfo->rotateDetectors(detectorsToRotate, axis, theta, center);
-  m_detectorInfo->rotatePathComponents(pathComponentsToRotate, axis, theta,
+  m_detectorInfo.rotateDetectors(detectorsToRotate, axis, theta, center);
+  m_detectorInfo.rotatePathComponents(pathComponentsToRotate, axis, theta,
                                        center);
 }
 

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -12,13 +12,11 @@
 #include "cow_ptr.h"
 #include "DetectorInfo.h"
 
-#include "IdType.h"
-
 /**
  * ComponentInfo type. Provides meta-data an behaviour for working with a
- * FlatTree
- * at the component level. Meta-data is provided per component. Add detectors
- * are components.
+ * FlatTree at the component level. Wraps DetectorInfo and PatchComponentInfo
+ * and therefore
+ * gives a Component only view of the data and associated operations.
  */
 template <typename InstTree> class ComponentInfo {
 public:

--- a/cow_instrument/DetectorInfo.h
+++ b/cow_instrument/DetectorInfo.h
@@ -312,8 +312,8 @@ void DetectorInfo<InstTree>::rotateDetector(size_t detectorIndex,
       Translation3d(center) * AngleAxisd(theta, axis) * Translation3d(-center);
   const auto rotation = transform.rotation();
 
-  (*m_positions)[detectorIndex] = transform * (*m_positions)[index];
-  (*m_rotations)[detectorIndex] = rotation * (*m_rotations)[index];
+  (*m_positions)[detectorIndex] = transform * (*m_positions)[detectorIndex];
+  (*m_rotations)[detectorIndex] = rotation * (*m_rotations)[detectorIndex];
 
   // Only l2 needs to be recalculated.
   initL2();
@@ -330,8 +330,8 @@ void DetectorInfo<InstTree>::rotateDetectors(
   const auto rotation = transform.rotation();
   for (auto &detIndex : detectorIndexes) {
 
-    (*m_positions)[detIndex] = transform * (*m_positions)[index];
-    (*m_rotations)[detIndex] = rotation * (*m_rotations)[index];
+    (*m_positions)[detIndex] = transform * (*m_positions)[detIndex];
+    (*m_rotations)[detIndex] = rotation * (*m_rotations)[detIndex];
   }
   // Only l2 needs to be recalculated.
   initL2();

--- a/cow_instrument/DetectorInfo.h
+++ b/cow_instrument/DetectorInfo.h
@@ -48,9 +48,9 @@ public:
 
   double l2(size_t detectorIndex) const;
 
-  Eigen::Vector3d positionDetector(size_t detectorIndex) const;
+  Eigen::Vector3d position(size_t detectorIndex) const;
 
-  Eigen::Quaterniond rotationDetector(size_t detectorIndex) const;
+  Eigen::Quaterniond rotation(size_t detectorIndex) const;
 
   double l1(size_t detectorIndex) const;
 
@@ -325,15 +325,14 @@ double DetectorInfo<InstTree>::l2(size_t detectorIndex) const {
 }
 
 template <typename InstTree>
-Eigen::Vector3d
-DetectorInfo<InstTree>::positionDetector(size_t detectorIndex) const {
+Eigen::Vector3d DetectorInfo<InstTree>::position(size_t detectorIndex) const {
 
   return (*m_positions)[detectorIndex];
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
-DetectorInfo<InstTree>::rotationDetector(size_t detectorIndex) const {
+DetectorInfo<InstTree>::rotation(size_t detectorIndex) const {
   return (*m_rotations)[detectorIndex];
 }
 

--- a/cow_instrument/FlatTree.cpp
+++ b/cow_instrument/FlatTree.cpp
@@ -50,6 +50,7 @@ FlatTree::FlatTree(std::shared_ptr<Component> componentRoot)
   m_pathLengths = treeParser.pathLengths();
   m_pathComponentIndexes = treeParser.pathComponentIndexes();
   m_detectorComponentIndexes = treeParser.detectorComponentIndexes();
+  m_branchNodeComponentIndexes = treeParser.branchNodeComponentIndexes();
   m_detectorIds = treeParser.detectorIds();
 }
 
@@ -72,6 +73,7 @@ FlatTree::FlatTree(std::shared_ptr<Component> componentRoot)
  * @param pathLengths
  * @param pathComponentIndexes
  * @param detectorComponentIndexes
+ * @param branchNodeComponentIndexes
  * @param detectorIds
  * @param sourceIndex
  * @param sampleIndex
@@ -85,6 +87,7 @@ FlatTree::FlatTree(std::vector<ComponentProxy> &&proxies,
                    std::vector<double> &&pathLengths,
                    std::vector<size_t> &&pathComponentIndexes,
                    std::vector<size_t> &&detectorComponentIndexes,
+                   std::vector<size_t> &&branchNodeComponentIndexes,
                    std::vector<DetectorIdType> &&detectorIds,
                    size_t sourceIndex, size_t sampleIndex)
     : m_proxies(std::move(proxies)), m_positions(std::move(positions)),
@@ -95,9 +98,13 @@ FlatTree::FlatTree(std::vector<ComponentProxy> &&proxies,
       m_pathLengths(std::move(pathLengths)),
       m_pathComponentIndexes(std::move(pathComponentIndexes)),
       m_detectorComponentIndexes(std::move(detectorComponentIndexes)),
+      m_branchNodeComponentIndexes(std::move(branchNodeComponentIndexes)),
       m_detectorIds(std::move(detectorIds)), m_sourceIndex(sourceIndex),
       m_sampleIndex(sampleIndex) {
-  // Note that m_rootComponent is not set because we don't have one.
+  /* Note that m_rootComponent is not set because we don't have one.
+     This will currently stop serialization working from this construction mode.
+     However,
+     serialization is due an update anyway */
 }
 
 const ComponentProxy &FlatTree::rootProxy() const { return m_proxies[0]; }
@@ -185,6 +192,10 @@ std::vector<size_t> FlatTree::pathComponentIndexes() const {
   return m_pathComponentIndexes;
 }
 
+std::vector<size_t> FlatTree::branchNodeComponentIndexes() const {
+  return m_branchNodeComponentIndexes;
+}
+
 size_t FlatTree::detIndexToCompIndex(size_t detectorIndex) const {
   return m_detectorComponentIndexes[detectorIndex];
 }
@@ -229,4 +240,8 @@ bool FlatTree::operator==(const FlatTree &other) const {
 
 bool FlatTree::operator!=(const FlatTree &other) const {
   return !operator==(other);
+}
+
+size_t FlatTree::nBranchNodeComponents() const {
+  return componentSize() - nDetectors() - nPathComponents();
 }

--- a/cow_instrument/FlatTree.cpp
+++ b/cow_instrument/FlatTree.cpp
@@ -138,14 +138,25 @@ std::vector<size_t> FlatTree::subTreeIndexes(size_t proxyIndex) const {
                                 std::to_string(proxyIndex));
   }
 
+  // Note that the query proxy index is also returned
   std::vector<size_t> subtree = {proxyIndex};
   for (size_t index = 0; index < subtree.size(); ++index) {
-    auto &currentProxy = m_proxies[subtree[index]];
+    const auto &currentProxy = m_proxies[subtree[index]];
     const auto &currentChildren = currentProxy.children();
     std::copy(currentChildren.begin(), currentChildren.end(),
               std::back_inserter(subtree));
   }
   return subtree;
+}
+
+std::vector<size_t> FlatTree::nextLevelIndexes(size_t proxyIndex) const {
+  if (proxyIndex >= componentSize()) {
+    throw std::invalid_argument("No subtree for proxy index: " +
+                                std::to_string(proxyIndex));
+  }
+
+  const auto &currentProxy = m_proxies[proxyIndex];
+  return currentProxy.children();
 }
 
 std::vector<Eigen::Vector3d> FlatTree::startPositions() const {

--- a/cow_instrument/FlatTree.cpp
+++ b/cow_instrument/FlatTree.cpp
@@ -170,6 +170,10 @@ std::vector<size_t> FlatTree::detectorComponentIndexes() const {
   return m_detectorComponentIndexes;
 }
 
+std::vector<size_t> FlatTree::pathComponentIndexes() const {
+  return m_pathComponentIndexes;
+}
+
 size_t FlatTree::detIndexToCompIndex(size_t detectorIndex) const {
   return m_detectorComponentIndexes[detectorIndex];
 }

--- a/cow_instrument/FlatTree.h
+++ b/cow_instrument/FlatTree.h
@@ -65,6 +65,7 @@ public:
   std::vector<Eigen::Vector3d> startEntryPoints() const;
   std::vector<double> pathLengths() const;
   std::vector<size_t> detectorComponentIndexes() const;
+  std::vector<size_t> pathComponentIndexes() const;
 
   size_t detIndexToCompIndex(size_t detectorIndex) const;
   size_t pathIndexToCompIndex(size_t pathIndex) const;

--- a/cow_instrument/FlatTree.h
+++ b/cow_instrument/FlatTree.h
@@ -32,6 +32,7 @@ public:
            std::vector<double> &&pathLengths,
            std::vector<size_t> &&pathComponentIndexes,
            std::vector<size_t> &&detectorComponentIndexes,
+           std::vector<size_t> &&branchNodeComponentIndexes,
            std::vector<DetectorIdType> &&detectorIds, size_t sourceIndex,
            size_t sampleIndex);
 
@@ -42,6 +43,7 @@ public:
 
   size_t nDetectors() const;
   size_t nPathComponents() const;
+  size_t nBranchNodeComponents() const;
 
   const ComponentProxy &proxyAt(size_t index) const;
 
@@ -69,6 +71,7 @@ public:
   std::vector<double> pathLengths() const;
   std::vector<size_t> detectorComponentIndexes() const;
   std::vector<size_t> pathComponentIndexes() const;
+  std::vector<size_t> branchNodeComponentIndexes() const;
 
   size_t detIndexToCompIndex(size_t detectorIndex) const;
   size_t pathIndexToCompIndex(size_t pathIndex) const;
@@ -106,6 +109,7 @@ private:
   std::vector<double> m_pathLengths;          // For path components
   std::vector<size_t> m_pathComponentIndexes;
   std::vector<size_t> m_detectorComponentIndexes;
+  std::vector<size_t> m_branchNodeComponentIndexes;
   std::vector<DetectorIdType> m_detectorIds;
   std::shared_ptr<Component> m_componentRoot;
 };

--- a/cow_instrument/FlatTree.h
+++ b/cow_instrument/FlatTree.h
@@ -56,8 +56,11 @@ public:
   std::vector<ComponentProxy>::const_iterator cend() const;
 
   size_t componentSize() const;
-  /// Enable use to determine all sub-components.
+  /// Enable use to determine all sub-components proxy indexes.
   std::vector<size_t> subTreeIndexes(size_t proxyIndex) const;
+  /// Enable use to determine sub-component proxy indexes only down to the next
+  /// level.
+  std::vector<size_t> nextLevelIndexes(size_t proxyIndex) const;
 
   std::vector<Eigen::Vector3d> startPositions() const;
   std::vector<Eigen::Quaterniond> startRotations() const;

--- a/cow_instrument/LinkedTreeParser.cpp
+++ b/cow_instrument/LinkedTreeParser.cpp
@@ -29,7 +29,9 @@ void LinkedTreeParser::registerPathComponent(PathComponent const *const comp) {
 
 size_t
 LinkedTreeParser::registerComposite(CompositeComponent const *const comp) {
-  return coreUpdate(comp);
+  const size_t nextComponentIndex = coreUpdate(comp);
+  m_branchNodeComponentIndexes.push_back(nextComponentIndex);
+  return nextComponentIndex;
 }
 
 void LinkedTreeParser::registerDetector(const Detector *const comp,
@@ -56,7 +58,9 @@ void LinkedTreeParser::registerPathComponent(const PathComponent *const comp,
 
 size_t LinkedTreeParser::registerComposite(const CompositeComponent *const comp,
                                            size_t parentIndex) {
-  return coreUpdate(comp, parentIndex);
+  const size_t nextComponentIndex = coreUpdate(comp, parentIndex);
+  m_branchNodeComponentIndexes.push_back(nextComponentIndex);
+  return nextComponentIndex;
 }
 
 std::vector<ComponentProxy> LinkedTreeParser::proxies() { return m_proxies; }
@@ -77,6 +81,10 @@ std::vector<size_t> LinkedTreeParser::pathComponentIndexes() const {
 
 std::vector<size_t> LinkedTreeParser::detectorComponentIndexes() const {
   return m_detectorComponentIndexes;
+}
+
+std::vector<size_t> LinkedTreeParser::branchNodeComponentIndexes() const {
+  return m_branchNodeComponentIndexes;
 }
 
 std::vector<Eigen::Vector3d> LinkedTreeParser::startEntryPoints() const {

--- a/cow_instrument/LinkedTreeParser.h
+++ b/cow_instrument/LinkedTreeParser.h
@@ -35,6 +35,7 @@ public:
   size_t pathSize() const;
   std::vector<size_t> pathComponentIndexes() const;
   std::vector<size_t> detectorComponentIndexes() const;
+  std::vector<size_t> branchNodeComponentIndexes() const;
   std::vector<Eigen::Vector3d> startEntryPoints() const;
   std::vector<Eigen::Vector3d> startExitPoints() const;
   std::vector<double> pathLengths() const;
@@ -74,6 +75,7 @@ private:
   std::vector<double> m_pathLengths;          // For path components
   std::vector<size_t> m_pathComponentIndexes;
   std::vector<size_t> m_detectorComponentIndexes;
+  std::vector<size_t> m_branchNodeComponentIndexes;
   std::vector<DetectorIdType> m_detectorIds;
 };
 

--- a/cow_instrument/PathComponentInfo.h
+++ b/cow_instrument/PathComponentInfo.h
@@ -14,8 +14,6 @@
 template <typename InstTree> class PathComponentInfo {
 
 public:
-  // template <typename InstSptrType>
-  // explicit PathComponentInfo(InstSptrType &&instrumentTree);
 
   explicit PathComponentInfo(std::shared_ptr<InstTree> &instrumentTree);
 

--- a/cow_instrument/PathComponentInfo.h
+++ b/cow_instrument/PathComponentInfo.h
@@ -175,7 +175,6 @@ PathComponentInfo<InstTree>::movePathComponent(size_t pathComponentIndex,
   (*m_entryPoints)[pathComponentIndex] += offset;
   (*m_exitPoints)[pathComponentIndex] += offset;
 
-  // Would need to update detectorInfo?
 }
 
 template <typename InstTree>
@@ -189,7 +188,6 @@ void PathComponentInfo<InstTree>::movePathComponents(
     (*m_exitPoints)[pathComponentIndex] += offset;
   }
 
-  // Would need to update detectorInfo?
 }
 
 template <typename InstTree>
@@ -211,7 +209,6 @@ void PathComponentInfo<InstTree>::rotatePathComponent(
   (*m_rotations)[pathComponentIndex] =
       rotation * (*m_rotations)[pathComponentIndex];
 
-  // Would need to update detectorInfo?
 }
 
 template <typename InstTree>

--- a/cow_instrument/PathComponentInfo.h
+++ b/cow_instrument/PathComponentInfo.h
@@ -59,9 +59,9 @@ private:
   CowPtr<std::vector<Eigen::Vector3d>> m_exitPoints;
   /// All path component entry points.
   std::shared_ptr<const std::vector<double>> m_pathLengths;
-  /// Locally (detector) indexed positions
+  /// Locally (path component) indexed positions
   CowPtr<std::vector<Eigen::Vector3d>> m_positions;
-  /// Locally (detector) indexed rotations
+  /// Locally (path component) indexed rotations
   CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
   /// Path component indexes
   std::shared_ptr<const std::vector<size_t>> m_pathComponentIndexes;

--- a/cow_instrument/benchmark/CMakeLists.txt
+++ b/cow_instrument/benchmark/CMakeLists.txt
@@ -30,6 +30,8 @@ set ( BENCH_FILES_SRC
                  InstrumentSerializationBenchmark.cpp
                  ComponentInfoWriteTranslateBenchmark.cpp
                  ComponentInfoWriteRotateBenchmark.cpp
+                 DetectorInfoWriteTranslateBenchmark.cpp
+                 DetectorInfoWriteRotateBenchmark.cpp
                  SpectrumInfoBenchmark.cpp
                  StandardInstrument.cpp
 )

--- a/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
@@ -1,6 +1,7 @@
 #include "StandardInstrument.h"
 #include <benchmark/benchmark_api.h>
 
+#include <stdexcept>
 namespace {
 
 class ComponentInfoWriteRotateFixture : public StandardInstrumentFixture {
@@ -23,7 +24,10 @@ public:
         size_t nComponents =
             m_componentInfo.const_instrumentTree().componentSize();
         for (size_t i = 0; i < nComponents; ++i) {
-          benchmark::DoNotOptimize(pos += m_componentInfo.position(i));
+          // throw std::runtime_error("This benchmark doesn't make sense any
+          // more");
+          benchmark::DoNotOptimize(pos +=
+                                   m_componentInfo.positionOfPathComponent(i));
         }
       }
     }

--- a/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
@@ -26,8 +26,7 @@ public:
         for (size_t i = 0; i < nComponents; ++i) {
           // throw std::runtime_error("This benchmark doesn't make sense any
           // more");
-          benchmark::DoNotOptimize(pos +=
-                                   m_componentInfo.positionOfPathComponent(i));
+          benchmark::DoNotOptimize(pos += m_componentInfo.position(i));
         }
       }
     }

--- a/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
@@ -12,7 +12,6 @@ public:
     Eigen::Vector3d axis{0, 0, 1};
     auto angle = M_PI / 2;
     Eigen::Vector3d center{0, 0, 0};
-    const auto &componentInfo = m_detectorInfo.componentInfo();
 
     while (state.KeepRunning()) {
       // Then modify that node

--- a/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteRotateBenchmark.cpp
@@ -24,8 +24,6 @@ public:
         size_t nComponents =
             m_componentInfo.const_instrumentTree().componentSize();
         for (size_t i = 0; i < nComponents; ++i) {
-          // throw std::runtime_error("This benchmark doesn't make sense any
-          // more");
           benchmark::DoNotOptimize(pos += m_componentInfo.position(i));
         }
       }

--- a/cow_instrument/benchmark/ComponentInfoWriteTranslateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteTranslateBenchmark.cpp
@@ -21,8 +21,7 @@ public:
         size_t nComponents =
             m_componentInfo.const_instrumentTree().componentSize();
         for (size_t i = 0; i < nComponents; ++i) {
-          benchmark::DoNotOptimize(pos +=
-                                   m_componentInfo.positionOfPathComponent(i));
+          benchmark::DoNotOptimize(pos += m_componentInfo.position(i));
         }
       }
     }

--- a/cow_instrument/benchmark/ComponentInfoWriteTranslateBenchmark.cpp
+++ b/cow_instrument/benchmark/ComponentInfoWriteTranslateBenchmark.cpp
@@ -21,7 +21,8 @@ public:
         size_t nComponents =
             m_componentInfo.const_instrumentTree().componentSize();
         for (size_t i = 0; i < nComponents; ++i) {
-          benchmark::DoNotOptimize(pos += m_componentInfo.position(i));
+          benchmark::DoNotOptimize(pos +=
+                                   m_componentInfo.positionOfPathComponent(i));
         }
       }
     }

--- a/cow_instrument/benchmark/DetectorInfoReadBenchmark.cpp
+++ b/cow_instrument/benchmark/DetectorInfoReadBenchmark.cpp
@@ -11,7 +11,7 @@ BENCHMARK_F(DetectorInfoReadFixture,
   const size_t max = m_detectorInfo.detectorSize();
   while (state.KeepRunning()) {
     for (size_t i = 1; i < max; ++i) {
-      benchmark::DoNotOptimize(m_detectorInfo.positionDetector(i));
+      benchmark::DoNotOptimize(m_detectorInfo.position(i));
     }
   }
   state.SetItemsProcessed(state.iterations() * max);
@@ -23,7 +23,7 @@ BENCHMARK_F(DetectorInfoReadFixture,
   const size_t max = m_detectorInfo.detectorSize();
   while (state.KeepRunning()) {
     for (size_t i = 1; i < max; ++i) {
-      benchmark::DoNotOptimize(m_detectorInfo.rotationDetector(i));
+      benchmark::DoNotOptimize(m_detectorInfo.rotation(i));
     }
   }
   state.SetItemsProcessed(state.iterations() * max);
@@ -35,7 +35,7 @@ BENCHMARK_F(DetectorInfoReadFixture,
   const size_t max = m_detectorInfo.detectorSize(); // ndetectors
   while (state.KeepRunning()) {
     for (size_t i = 1; i < max; ++i) {
-      benchmark::DoNotOptimize(m_detectorInfo.positionDetector(i));
+      benchmark::DoNotOptimize(m_detectorInfo.position(i));
     }
   }
   state.SetItemsProcessed(state.iterations() * max);
@@ -47,7 +47,7 @@ BENCHMARK_F(DetectorInfoReadFixture,
   const size_t max = m_detectorInfo.detectorSize(); // ndetectors
   while (state.KeepRunning()) {
     for (size_t i = 1; i < max; ++i) {
-      benchmark::DoNotOptimize(m_detectorInfo.rotationDetector(i));
+      benchmark::DoNotOptimize(m_detectorInfo.rotation(i));
     }
   }
   state.SetItemsProcessed(state.iterations() * max);

--- a/cow_instrument/benchmark/DetectorInfoWriteRotateBenchmark.cpp
+++ b/cow_instrument/benchmark/DetectorInfoWriteRotateBenchmark.cpp
@@ -1,0 +1,58 @@
+#include "StandardInstrument.h"
+#include <benchmark/benchmark_api.h>
+#include <stdexcept>
+#include <numeric>
+
+namespace {
+
+class DetectorInfoWriteRotateFixture : public StandardInstrumentFixture {
+
+public:
+  void rotateOneDetector(benchmark::State &state) {
+
+    Eigen::Vector3d axis{0, 0, 1};
+    auto angle = M_PI / 2;
+    Eigen::Vector3d center{0, 0, 0};
+
+    while (state.KeepRunning()) {
+      // Then modify that node
+
+      m_detectorInfo.rotateDetector(0, axis, angle, center);
+
+      // For statistics. Mark the number of itertions
+      state.SetItemsProcessed(state.iterations() * 1);
+    }
+  }
+
+  void rotateDetectorsAsBatch(benchmark::State &state) {
+
+    std::vector<size_t> detectorIndexes(m_detectorInfo.detectorSize());
+    std::iota(detectorIndexes.begin(), detectorIndexes.end(), 0);
+
+    Eigen::Vector3d axis{0, 0, 1};
+    auto angle = M_PI / 2;
+    Eigen::Vector3d center{0, 0, 0};
+
+    while (state.KeepRunning()) {
+      // Then modify that node
+
+      m_detectorInfo.rotateDetectors(detectorIndexes, axis, angle, center);
+
+      // For statistics. Mark the number of itertions
+      state.SetItemsProcessed(state.iterations() *
+                              m_detectorInfo.detectorSize());
+    }
+  }
+};
+
+BENCHMARK_F(DetectorInfoWriteRotateFixture,
+            BM_rotate_bank_one_by_one)(benchmark::State &state) {
+  this->rotateOneDetector(state);
+}
+
+BENCHMARK_F(DetectorInfoWriteRotateFixture,
+            BM_rotate_bank_at_once)(benchmark::State &state) {
+  this->rotateDetectorsAsBatch(state);
+}
+
+} // namespace

--- a/cow_instrument/benchmark/DetectorInfoWriteTranslateBenchmark.cpp
+++ b/cow_instrument/benchmark/DetectorInfoWriteTranslateBenchmark.cpp
@@ -1,0 +1,54 @@
+#include "StandardInstrument.h"
+#include <benchmark/benchmark_api.h>
+#include <stdexcept>
+#include <numeric>
+
+namespace {
+
+class DetectorInfoWriteTranslateFixture : public StandardInstrumentFixture {
+
+public:
+  void moveBankOneDetector(benchmark::State &state) {
+
+    Eigen::Vector3d offset{1, 0, 0};
+
+    while (state.KeepRunning()) {
+      // Then modify that node
+
+      m_detectorInfo.moveDetector(0, offset);
+
+      // For statistics. Mark the number of itertions
+      state.SetItemsProcessed(state.iterations() * 1);
+    }
+  }
+
+  void moveDetectorsAsBatch(benchmark::State &state) {
+
+    std::vector<size_t> detectorIndexes(m_detectorInfo.detectorSize());
+    std::iota(detectorIndexes.begin(), detectorIndexes.end(), 0);
+
+    Eigen::Vector3d offset{1, 0, 0};
+
+    while (state.KeepRunning()) {
+      // Then modify that node
+
+      m_detectorInfo.moveDetectors(detectorIndexes, offset);
+
+      // For statistics. Mark the number of itertions
+      state.SetItemsProcessed(state.iterations() *
+                              m_detectorInfo.detectorSize());
+    }
+  }
+};
+
+BENCHMARK_F(DetectorInfoWriteTranslateFixture,
+            BM_translate_bank_one_by_one)(benchmark::State &state) {
+  this->moveBankOneDetector(state);
+}
+
+BENCHMARK_F(DetectorInfoWriteTranslateFixture,
+            BM_translate_bank_at_once)(benchmark::State &state) {
+  this->moveDetectorsAsBatch(state);
+}
+
+} // namespace

--- a/cow_instrument/benchmark/StandardInstrument.cpp
+++ b/cow_instrument/benchmark/StandardInstrument.cpp
@@ -85,8 +85,10 @@ std::shared_ptr<Component> construct_root_component() {
 StandardInstrumentFixture::StandardInstrumentFixture()
     : StandardBenchmark<StandardInstrumentFixture>(),
       m_instrument(std_instrument::construct_root_component()),
-      m_componentInfo(std::make_shared<FlatTree>(
-          std_instrument::construct_root_component())),
+      m_componentInfo(std::make_shared<DetectorInfo<FlatTree>>(
+          std::make_shared<FlatTree>(
+              std_instrument::construct_root_component()),
+          SourceSampleDetectorPathFactory<FlatTree>{})),
       m_detectorInfo(std::make_shared<FlatTree>(
                          std_instrument::construct_root_component()),
                      SourceSampleDetectorPathFactory<FlatTree>{}) {}

--- a/cow_instrument/benchmark/StandardInstrument.cpp
+++ b/cow_instrument/benchmark/StandardInstrument.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<Component> construct_root_component() {
 StandardInstrumentFixture::StandardInstrumentFixture()
     : StandardBenchmark<StandardInstrumentFixture>(),
       m_instrument(std_instrument::construct_root_component()),
-      m_componentInfo(std::make_shared<DetectorInfo<FlatTree>>(
+      m_componentInfo(DetectorInfo<FlatTree>(
           std::make_shared<FlatTree>(
               std_instrument::construct_root_component()),
           SourceSampleDetectorPathFactory<FlatTree>{})),

--- a/cow_instrument/testing/CMakeLists.txt
+++ b/cow_instrument/testing/CMakeLists.txt
@@ -41,6 +41,7 @@ set ( TEST_FILES
                  LinkedTreeParserTest.cpp
                  ParabolicGuideTest.cpp
                  PathComponentTest.cpp
+                 PathComponentInfoTest.cpp
                  PointPathComponentTest.cpp
                  SourceSampleDetectorPathFactoryTest.cpp                 
                  SpectrumInfoTest.cpp

--- a/cow_instrument/testing/ComponentInfoTest.cpp
+++ b/cow_instrument/testing/ComponentInfoTest.cpp
@@ -219,4 +219,19 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 0, 1}, 1e-14))
       << "Internal component rotation not updated correctly";
 }
+
+TEST(component_info_test, test_detector_info_constructor) {
+  using namespace testing;
+
+  MockPathFactory mockPathFactory;
+  EXPECT_CALL(mockPathFactory, createL1(testing::_))
+      .WillOnce(testing::Return(new Paths(0, Path{0})));
+  EXPECT_CALL(mockPathFactory, createL2(testing::_))
+      .WillOnce(testing::Return(new Paths(0, Path{0})));
+
+  auto detectorInfo = std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+      std::make_shared<NiceMockInstrumentTree>(), mockPathFactory);
+
+  ComponentInfo<NiceMockInstrumentTree> compInfo{detectorInfo};
+}
 }

--- a/cow_instrument/testing/ComponentInfoTest.cpp
+++ b/cow_instrument/testing/ComponentInfoTest.cpp
@@ -55,7 +55,7 @@ TEST(component_info_test, test_construct) {
   std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
 
   ComponentInfoWithMockInstrument{
-      std::make_shared<DetectorInfo<MockFlatTree>>(mockInstrumentTree)};
+      DetectorInfo<MockFlatTree>(mockInstrumentTree)};
 
   EXPECT_TRUE(testing::Mock::VerifyAndClear(pMockInstrumentTree))
       << "InstrumentTree used incorrectly";
@@ -72,8 +72,7 @@ TEST(component_info_test, test_move) {
       .WillOnce(Return(std::vector<size_t>{0}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
 
   auto before = componentInfo.position(0);
@@ -103,7 +102,7 @@ TEST(component_info_test, test_single_rotation_around_component_origin) {
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
   auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+      DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
 
   const size_t sampleComponentIndex = 0;
@@ -151,7 +150,7 @@ TEST(component_info_test, test_multiple_rotation_around_component_origin) {
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
   auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+      DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
 
   const size_t sampleComponentIndex = 0;
@@ -201,7 +200,7 @@ TEST(component_info_test, test_single_rotation_around_arbitrary_center) {
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
   auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+      DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
   const size_t sampleComponentIndex = 0;
 
@@ -242,7 +241,7 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
   auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
+      DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
   const size_t sampleComponentIndex = 0;
 
@@ -269,8 +268,7 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
 
 TEST(component_info_test, test_position) {
 
-  auto detectorInfo =
-      std::make_shared<DetectorInfo<FlatTree>>(makeInstrumentTree());
+  auto detectorInfo = DetectorInfo<FlatTree>(makeInstrumentTree());
 
   ComponentInfo<FlatTree> componentInfo(detectorInfo);
 

--- a/cow_instrument/testing/ComponentInfoTest.cpp
+++ b/cow_instrument/testing/ComponentInfoTest.cpp
@@ -1,4 +1,9 @@
 #include "ComponentInfo.h"
+#include "CompositeComponent.h"
+#include "DetectorComponent.h"
+#include "DetectorInfo.h"
+#include "PointSample.h"
+#include "PointSource.h"
 #include "FlatTree.h"
 #include "MockTypes.h"
 #include <gtest/gtest.h>
@@ -9,6 +14,36 @@
 #include "IdType.h"
 
 namespace {
+
+std::shared_ptr<FlatTree> makeInstrumentTree() {
+  /*
+
+        A
+        |
+ ------------------------------
+ |                |           |
+ B                C           D
+                              |
+                              E
+
+
+  */
+
+  auto a = std::make_shared<CompositeComponent>(ComponentIdType(1));
+  a->addComponent(std::unique_ptr<DetectorComponent>(new DetectorComponent(
+      ComponentIdType(2), DetectorIdType(1), Eigen::Vector3d{1, 1, 1})));
+  a->addComponent(std::unique_ptr<PointSource>(
+      new PointSource(Eigen::Vector3d{-1, 0, 0}, ComponentIdType(3))));
+
+  auto d = std::unique_ptr<CompositeComponent>(
+      new CompositeComponent(ComponentIdType(4)));
+  d->addComponent(std::unique_ptr<PointSample>(
+      new PointSample(Eigen::Vector3d{0.1, 0, 0}, ComponentIdType(5))));
+
+  a->addComponent(std::move(d));
+
+  return std::make_shared<FlatTree>(a);
+}
 
 TEST(component_info_test, test_construct) {
 
@@ -41,10 +76,10 @@ TEST(component_info_test, test_move) {
       std::make_shared<DetectorInfo<NiceMockInstrumentTree>>(
           mockInstrumentTree)};
 
-  auto before = componentInfo.positionOfPathComponent(0);
+  auto before = componentInfo.position(0);
   auto offset = Eigen::Vector3d{1, 0, 0};
   componentInfo.move(0, offset);
-  auto after = componentInfo.positionOfPathComponent(0);
+  auto after = componentInfo.position(0);
 
   EXPECT_EQ(after, before + offset);
   EXPECT_TRUE(Mock::VerifyAndClearExpectations(instrumentTree));
@@ -75,20 +110,20 @@ TEST(component_info_test, test_single_rotation_around_component_origin) {
 
   const Eigen::Vector3d rotationAxis{0, 0, 1};
   const double rotationAngle = M_PI / 2;
-  const Eigen::Vector3d rotationCenter{componentInfo.positionOfPathComponent(
+  const Eigen::Vector3d rotationCenter{componentInfo.position(
       sampleComponentIndex)}; // rotate around component center
 
   componentInfo.rotate(sampleComponentIndex, rotationAxis, rotationAngle,
                        rotationCenter);
 
-  auto after = componentInfo.rotationOfPathComponent(sampleComponentIndex);
+  auto after = componentInfo.rotation(sampleComponentIndex);
   auto rotMatrix = after.toRotationMatrix();
   // Check that some vector I define gets rotated as I would expect
   Eigen::Vector3d rotatedVector = rotMatrix * Eigen::Vector3d{1, 0, 0};
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
       << "Internal rotation not updated correctly";
 
-  EXPECT_TRUE(componentInfo.positionOfPathComponent(sampleComponentIndex)
+  EXPECT_TRUE(componentInfo.position(sampleComponentIndex)
                   .isApprox(Eigen::Vector3d{0, 0, 0}, 1e-14))
       << "Position should be unchanged as rotation was around its own center";
 
@@ -128,8 +163,7 @@ TEST(component_info_test, test_multiple_rotation_around_component_origin) {
   componentInfo.rotate(sampleComponentIndex, rotationAxis, rotationAngle,
                        rotationCenter);
 
-  auto samplePosition =
-      componentInfo.positionOfPathComponent(sampleComponentIndex);
+  auto samplePosition = componentInfo.position(sampleComponentIndex);
 
   // Check that the position has not changed
   EXPECT_TRUE(samplePosition.isApprox(rotationCenter, 1e-14))
@@ -138,8 +172,7 @@ TEST(component_info_test, test_multiple_rotation_around_component_origin) {
   // Check that the internal rotation gets updated. i.e component is rotated
   // around its own centre.
   Eigen::Matrix3d rotMatrix =
-      componentInfo.rotationOfPathComponent(sampleComponentIndex)
-          .toRotationMatrix();
+      componentInfo.rotation(sampleComponentIndex).toRotationMatrix();
   // Check that some vector I define gets rotated as I would expect
   Eigen::Vector3d rotatedVector = rotMatrix * Eigen::Vector3d{1, 0, 0};
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
@@ -175,13 +208,12 @@ TEST(component_info_test, test_single_rotation_around_arbitrary_center) {
   componentInfo.rotate(sampleComponentIndex, rotationAxis, rotationAngle,
                        rotationCenter);
   // Check that the position has the rotation applied.
-  EXPECT_TRUE(componentInfo.positionOfPathComponent(sampleComponentIndex)
+  EXPECT_TRUE(componentInfo.position(sampleComponentIndex)
                   .isApprox(Eigen::Vector3d(0, 1, 0), 1e-14));
 
   // Check that the internal rotation gets updated
   Eigen::Matrix3d rotMatrix =
-      componentInfo.rotationOfPathComponent(sampleComponentIndex)
-          .toRotationMatrix();
+      componentInfo.rotation(sampleComponentIndex).toRotationMatrix();
   // Check that some vector I define gets rotated as I would expect
   Eigen::Vector3d rotatedVector = rotMatrix * Eigen::Vector3d{1, 0, 0};
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
@@ -222,18 +254,41 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
                        rotationCenter);
 
   // Check that the position has the rotations applied.
-  EXPECT_TRUE(componentInfo.positionOfPathComponent(sampleComponentIndex)
+  EXPECT_TRUE(componentInfo.position(sampleComponentIndex)
                   .isApprox(Eigen::Vector3d(0, 0, 1), 1e-14));
 
   // Check that the internal rotation gets updated. i.e component is rotated
   // around its own centre.
   Eigen::Matrix3d rotMatrix =
-      componentInfo.rotationOfPathComponent(sampleComponentIndex)
-          .toRotationMatrix();
+      componentInfo.rotation(sampleComponentIndex).toRotationMatrix();
   // Check that some vector I define gets rotated as I would expect
   Eigen::Vector3d rotatedVector = rotMatrix * Eigen::Vector3d{1, 0, 0};
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 0, 1}, 1e-14))
       << "Internal component rotation not updated correctly";
 }
 
+TEST(component_info_test, test_position) {
+
+  auto detectorInfo =
+      std::make_shared<DetectorInfo<FlatTree>>(makeInstrumentTree());
+
+  ComponentInfo<FlatTree> componentInfo(detectorInfo);
+
+  auto posB = componentInfo.position(1); // Detector
+  auto posC = componentInfo.position(2); // path component (source)
+  auto posD = componentInfo.position(3); // composite
+  auto posE = componentInfo.position(4); // path component (sample)
+
+  EXPECT_EQ(posB, Eigen::Vector3d(1, 1, 1)) << "Detector position incorrect";
+  EXPECT_EQ(posC, Eigen::Vector3d(-1, 0, 0)) << "Source position incorrect";
+  EXPECT_EQ(posE, Eigen::Vector3d(0.1, 0, 0)) << "Sanity check position of E";
+  EXPECT_EQ(posD, posE) << "D is just a composite containing E, so the "
+                           "positions should be the same";
+
+  auto posA = componentInfo.position(0); // composite (whole instrument)
+
+  EXPECT_EQ(posA, (posB + posC + posE) / 3);
+  EXPECT_NE(posA, (posB + posC + posE + posD) / 4)
+      << "Composites (posD) should not be factored in";
+}
 }

--- a/cow_instrument/testing/DetectorInfoTest.cpp
+++ b/cow_instrument/testing/DetectorInfoTest.cpp
@@ -1,5 +1,4 @@
 #include "DetectorInfo.h"
-#include "FlatTree.h"
 #include "MockTypes.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/cow_instrument/testing/FlatTreeTest.cpp
+++ b/cow_instrument/testing/FlatTreeTest.cpp
@@ -164,6 +164,7 @@ TEST(instrument_tree_test, test_both_constructors) {
   auto exitPoints = intermediate.startExitPoints();
   auto pathLengths = intermediate.pathLengths();
   auto pathComponentIndexes = intermediate.pathComponentIndexes();
+  auto branchNodeComponentIndexes = intermediate.branchNodeComponentIndexes();
   auto detectorComponentIndexes = intermediate.detectorComponentIndexes();
   auto detectorIds = intermediate.detectorIds();
 
@@ -171,7 +172,8 @@ TEST(instrument_tree_test, test_both_constructors) {
       std::move(proxies), std::move(positions), std::move(rotations),
       std::move(componentIds), std::move(entryPoints), std::move(exitPoints),
       std::move(pathLengths), std::move(pathComponentIndexes),
-      std::move(detectorComponentIndexes), std::move(detectorIds),
+      std::move(detectorComponentIndexes),
+      std::move(branchNodeComponentIndexes), std::move(detectorIds),
       intermediate.sourcePathIndex(), intermediate.samplePathIndex());
 
   EXPECT_EQ(treeA.startPositions(), treeB.startPositions())
@@ -203,13 +205,15 @@ TEST(instrument_tree_test, test_fetching_root_component_failure) {
   auto pathLengths = intermediate.pathLengths();
   auto pathComponentIndexes = intermediate.pathComponentIndexes();
   auto detectorComponentIndexes = intermediate.detectorComponentIndexes();
+  auto branchNodeComponentIndexes = intermediate.branchNodeComponentIndexes();
   auto detectorIds = intermediate.detectorIds();
 
   FlatTree tree(std::move(proxies), std::move(positions), std::move(rotations),
                 std::move(componentIds), std::move(entryPoints),
                 std::move(exitPoints), std::move(pathLengths),
                 std::move(pathComponentIndexes),
-                std::move(detectorComponentIndexes), std::move(detectorIds),
+                std::move(detectorComponentIndexes),
+                std::move(branchNodeComponentIndexes), std::move(detectorIds),
                 intermediate.sourcePathIndex(), intermediate.samplePathIndex());
 
   EXPECT_TRUE(!tree.rootComponent()) << "We never set this";

--- a/cow_instrument/testing/FlatTreeTest.cpp
+++ b/cow_instrument/testing/FlatTreeTest.cpp
@@ -7,6 +7,7 @@
 #include "ParabolicGuide.h"
 #include "PointSource.h"
 #include "PointSample.h"
+#include "FlatTree.h"
 
 using namespace testing;
 

--- a/cow_instrument/testing/FlatTreeTest.cpp
+++ b/cow_instrument/testing/FlatTreeTest.cpp
@@ -280,7 +280,7 @@ TEST(instrument_tree_test,
 FlatTree makeInstrumentTree() {
   /*
 
-    we start like this. A-B-C-D-E are components within a single node.
+    we start like this. A-B-C-D-E are components
 
         A
         |
@@ -352,7 +352,8 @@ TEST(instrument_tree_test, test_subtree_search) {
   // Subtree of A
   auto indexes = instrument.subTreeIndexes(0);
   EXPECT_EQ(indexes, (std::vector<size_t>{0, 1, 2, 3, 4}))
-      << "Subtree for A. should include everything";
+      << "Subtree for A. should include everything including original query "
+         "proxy index";
 
   // Subtree of B
   indexes = instrument.subTreeIndexes(1);
@@ -371,6 +372,36 @@ TEST(instrument_tree_test, test_subtree_search) {
   // Subtree of E
   indexes = instrument.subTreeIndexes(4);
   EXPECT_EQ(indexes, (std::vector<size_t>{4})) << "Subtree for E incorrect";
+}
+
+TEST(instrument_tree_test, test_next_level_search) {
+  FlatTree instrument = makeInstrumentTree();
+
+  // Subtree of A
+  auto indexes = instrument.nextLevelIndexes(0);
+  EXPECT_EQ(indexes, (std::vector<size_t>{1, 2, 3}))
+      << "Next level for A wrong. should include only indexes for the next "
+         "level";
+
+  // Subtree of B
+  indexes = instrument.nextLevelIndexes(1);
+  EXPECT_EQ(indexes, (std::vector<size_t>()))
+      << "Next level for B wrong. Expected to be empty - no subtree";
+
+  // Subtree of C
+  indexes = instrument.nextLevelIndexes(2);
+  EXPECT_EQ(indexes, (std::vector<size_t>()))
+      << "Should be empty - no next level. Subtree for C incorrect";
+
+  // Subtree of D
+  indexes = instrument.nextLevelIndexes(3);
+  EXPECT_EQ(indexes, (std::vector<size_t>{4}))
+      << "Indexes for D incorrect - no next level";
+
+  // Subtree of E
+  indexes = instrument.nextLevelIndexes(4);
+  EXPECT_EQ(indexes, (std::vector<size_t>()))
+      << "Indexes for E incorrect. Should be empty - no next level";
 }
 
 TEST(instrument_tree_test, test_positions) {
@@ -412,6 +443,14 @@ TEST(instrument_tree_test, test_subtree_unreachable_throws) {
   FlatTree instrument = makeInstrumentTree();
 
   EXPECT_THROW(instrument.subTreeIndexes(instrument.componentSize()),
+               std::invalid_argument);
+}
+
+TEST(instrument_tree_test, test_nextlevel_unreachable_throws) {
+
+  FlatTree instrument = makeInstrumentTree();
+
+  EXPECT_THROW(instrument.nextLevelIndexes(instrument.componentSize()),
                std::invalid_argument);
 }
 }

--- a/cow_instrument/testing/MockTypes.h
+++ b/cow_instrument/testing/MockTypes.h
@@ -128,7 +128,7 @@ public:
     ON_CALL(*this, detectorComponentIndexes())
         .WillByDefault(testing::Return(std::vector<size_t>(nDetectors, 0)));
 
-    std::vector<size_t> pathComponentIndexesData(nDetectors + 1);
+    std::vector<size_t> pathComponentIndexesData(1);
     std::iota(pathComponentIndexesData.begin(), pathComponentIndexesData.end(),
               nDetectors);
     ON_CALL(*this, pathComponentIndexes())

--- a/cow_instrument/testing/MockTypes.h
+++ b/cow_instrument/testing/MockTypes.h
@@ -76,6 +76,7 @@ template <typename T> class PolymorphicFlatTree {
 public:
   virtual size_t nDetectors() const = 0;
   virtual size_t nPathComponents() const = 0;
+  virtual size_t nBranchNodeComponents() const = 0;
   virtual size_t samplePathIndex() const = 0;
   virtual size_t sourcePathIndex() const = 0;
   virtual size_t componentSize() const = 0;
@@ -90,6 +91,7 @@ public:
   virtual std::vector<double> pathLengths() const = 0;
   virtual std::vector<size_t> detectorComponentIndexes() const = 0;
   virtual std::vector<size_t> pathComponentIndexes() const = 0;
+  virtual std::vector<size_t> branchNodeComponentIndexes() const = 0;
   virtual ~PolymorphicFlatTree() {}
 };
 
@@ -158,6 +160,7 @@ public:
   }
   MOCK_CONST_METHOD0(nDetectors, size_t());
   MOCK_CONST_METHOD0(nPathComponents, size_t());
+  MOCK_CONST_METHOD0(nBranchNodeComponents, size_t());
   MOCK_CONST_METHOD0(samplePathIndex, size_t());
   MOCK_CONST_METHOD0(sourcePathIndex, size_t());
   MOCK_CONST_METHOD0(componentSize, size_t());
@@ -172,6 +175,7 @@ public:
   MOCK_CONST_METHOD0(pathLengths, std::vector<double>());
   MOCK_CONST_METHOD0(detectorComponentIndexes, std::vector<size_t>());
   MOCK_CONST_METHOD0(pathComponentIndexes, std::vector<size_t>());
+  MOCK_CONST_METHOD0(branchNodeComponentIndexes, std::vector<size_t>());
 
   virtual ~MockFlatTree() {}
 };

--- a/cow_instrument/testing/MockTypes.h
+++ b/cow_instrument/testing/MockTypes.h
@@ -82,6 +82,7 @@ public:
   virtual std::vector<Eigen::Vector3d> startPositions() const = 0;
   virtual std::vector<Eigen::Quaterniond> startRotations() const = 0;
   virtual std::vector<size_t> subTreeIndexes(size_t proxyIndex) const = 0;
+  virtual std::vector<size_t> nextLevelIndexes(size_t proxyIndex) const = 0;
   virtual size_t detIndexToCompIndex(size_t detectorIndex) const = 0;
   virtual size_t pathIndexToCompIndex(size_t pathIndex) const = 0;
   virtual std::vector<Eigen::Vector3d> startEntryPoints() const = 0;
@@ -157,13 +158,13 @@ public:
   }
   MOCK_CONST_METHOD0(nDetectors, size_t());
   MOCK_CONST_METHOD0(nPathComponents, size_t());
-  MOCK_CONST_METHOD1(getDetector, const Detector &(size_t));
   MOCK_CONST_METHOD0(samplePathIndex, size_t());
   MOCK_CONST_METHOD0(sourcePathIndex, size_t());
   MOCK_CONST_METHOD0(componentSize, size_t());
   MOCK_CONST_METHOD0(startPositions, std::vector<Eigen::Vector3d>());
   MOCK_CONST_METHOD0(startRotations, std::vector<Eigen::Quaterniond>());
   MOCK_CONST_METHOD1(subTreeIndexes, std::vector<size_t>(size_t));
+  MOCK_CONST_METHOD1(nextLevelIndexes, std::vector<size_t>(size_t));
   MOCK_CONST_METHOD1(detIndexToCompIndex, size_t(size_t));
   MOCK_CONST_METHOD1(pathIndexToCompIndex, size_t(size_t));
   MOCK_CONST_METHOD0(startEntryPoints, std::vector<Eigen::Vector3d>());

--- a/cow_instrument/testing/PathComponentInfoTest.cpp
+++ b/cow_instrument/testing/PathComponentInfoTest.cpp
@@ -107,11 +107,139 @@ TEST(path_info_test, test_out_of_bounds_access) {
       << "InstrumentTree used incorrectly";
 }
 
+void do_test_rotation(bool rotateAsSingleItem) {
+
+  using namespace testing;
+  // Instrument with single path component.
+  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
+  EXPECT_CALL(*pMockInstrumentTree, nPathComponents())
+      .WillRepeatedly(testing::Return(1));
+  EXPECT_CALL(*pMockInstrumentTree, startPositions())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {1, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startRotations())
+      .WillRepeatedly(testing::Return(std::vector<Eigen::Quaterniond>(
+          1, Eigen::Quaterniond(Eigen::Affine3d::Identity().rotation()))));
+  EXPECT_CALL(*pMockInstrumentTree, startEntryPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {-1, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startExitPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {2, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, pathComponentIndexes())
+      .WillRepeatedly(testing::Return(std::vector<size_t>(1, 0)));
+
+  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
+  PathComponentInfo<MockFlatTree> pathComponentInfo(mockInstrumentTree);
+
+  size_t pathComponentIndex = 0;
+
+  const Eigen::Vector3d rotationAxis{0, 0, 1}; // Rotate around z axis
+  const double rotationAngle = M_PI / 2;
+  const Eigen::Vector3d rotationCenter{0, 0, 0}; // rotate around origin
+
+  if (rotateAsSingleItem) {
+    pathComponentInfo.rotatePathComponent(pathComponentIndex, rotationAxis,
+                                          rotationAngle, rotationCenter);
+  } else {
+    // Create a vector of the argument but otherwise do the same as above.
+    std::vector<size_t> indexesToRotate(1, pathComponentIndex);
+    pathComponentInfo.rotatePathComponents(indexesToRotate, rotationAxis,
+                                           rotationAngle, rotationCenter);
+  }
+
+  auto after = pathComponentInfo.rotation(pathComponentIndex);
+  auto rotMatrix = after.toRotationMatrix();
+  // Check that some vector I define gets rotated as I would expect
+  Eigen::Vector3d rotatedVector = rotMatrix * Eigen::Vector3d{1, 0, 0};
+  EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
+      << "Internal rotation not updated correctly";
+
+  EXPECT_TRUE(pathComponentInfo.position(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
+      << "Position should be rotated around z";
+
+  EXPECT_TRUE(pathComponentInfo.entryPoint(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{0, -1, 0}, 1e-14))
+      << "Entry point should be rotated around z";
+
+  EXPECT_TRUE(pathComponentInfo.exitPoint(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{0, 2, 0}, 1e-14))
+      << "Exit point should be rotated around z";
+
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(pMockInstrumentTree));
+}
+
+void do_test_position(bool moveAsSingleItem) {
+
+  using namespace testing;
+  // Instrument with single path component.
+  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
+  EXPECT_CALL(*pMockInstrumentTree, nPathComponents())
+      .WillRepeatedly(testing::Return(1));
+  EXPECT_CALL(*pMockInstrumentTree, startPositions())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {1, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startRotations())
+      .WillRepeatedly(testing::Return(std::vector<Eigen::Quaterniond>(
+          1, Eigen::Quaterniond(Eigen::Affine3d::Identity().rotation()))));
+  EXPECT_CALL(*pMockInstrumentTree, startEntryPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {2, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startExitPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {3, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, pathComponentIndexes())
+      .WillRepeatedly(testing::Return(std::vector<size_t>(1, 0)));
+
+  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
+  PathComponentInfo<MockFlatTree> pathComponentInfo(mockInstrumentTree);
+
+  size_t pathComponentIndex = 0;
+  Eigen::Vector3d offset{1, 0, 0};
+
+  if (moveAsSingleItem) {
+    pathComponentInfo.movePathComponent(pathComponentIndex, offset);
+  } else {
+    // Create a vector of the argument but otherwise do the same as above.
+    std::vector<size_t> indexesToMove(1, pathComponentIndex);
+    pathComponentInfo.movePathComponents(indexesToMove, offset);
+  }
+
+  EXPECT_TRUE(pathComponentInfo.position(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{2, 0, 0}, 1e-14))
+      << "Position should be shiftd along x";
+
+  EXPECT_TRUE(pathComponentInfo.entryPoint(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{3, 0, 0}, 1e-14))
+      << "Entry should be shiftd along x";
+
+  EXPECT_TRUE(pathComponentInfo.exitPoint(pathComponentIndex)
+                  .isApprox(Eigen::Vector3d{4, 0, 0}, 1e-14))
+      << "Exit should be shiftd along x";
+
+  EXPECT_TRUE(Mock::VerifyAndClearExpectations(pMockInstrumentTree));
+}
+
 TEST(path_info_test, test_rotation) {
-  // TODO
+
+  bool rotateAsSingleItem = true;
+  do_test_rotation(rotateAsSingleItem);
+}
+
+TEST(path_info_test, test_rotations) {
+
+  bool rotateAsSingleItem = false;
+  do_test_rotation(rotateAsSingleItem);
 }
 
 TEST(path_info_test, test_position) {
-  // TODO
+  bool moveAsSingleItem = true;
+  do_test_position(moveAsSingleItem);
+}
+
+TEST(path_info_test, test_positions) {
+  bool moveAsSingleItem = false;
+  do_test_position(moveAsSingleItem);
 }
 }

--- a/cow_instrument/testing/PathComponentInfoTest.cpp
+++ b/cow_instrument/testing/PathComponentInfoTest.cpp
@@ -1,0 +1,117 @@
+
+#include "FlatTree.h"
+#include "MockTypes.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <stdexcept>
+#include <memory>
+#include "PathComponentInfo.h"
+
+namespace {
+
+TEST(path_info_test, test_construct_simple) {
+
+  using namespace testing;
+  // Instrument with single path component. Nothing else.
+  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
+  EXPECT_CALL(*pMockInstrumentTree, nPathComponents())
+      .WillRepeatedly(testing::Return(1));
+  EXPECT_CALL(*pMockInstrumentTree, startPositions())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {0.5, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startRotations())
+      .WillRepeatedly(testing::Return(std::vector<Eigen::Quaterniond>(
+          1, Eigen::Quaterniond(Eigen::Affine3d::Identity().rotation()))));
+  EXPECT_CALL(*pMockInstrumentTree, startEntryPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {0, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startExitPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(1, {1, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, pathComponentIndexes())
+      .WillRepeatedly(testing::Return(std::vector<size_t>(1, 0)));
+
+  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
+  PathComponentInfo<MockFlatTree> pathComponentInfo(mockInstrumentTree);
+
+  EXPECT_EQ(pathComponentInfo.position(0), (Eigen::Vector3d{0.5, 0, 0}));
+  EXPECT_EQ(pathComponentInfo.entryPoint(0), (Eigen::Vector3d{0, 0, 0}));
+  EXPECT_EQ(pathComponentInfo.exitPoint(0), (Eigen::Vector3d{1, 0, 0}));
+
+  EXPECT_TRUE(testing::Mock::VerifyAndClear(pMockInstrumentTree))
+      << "InstrumentTree used incorrectly";
+}
+
+TEST(path_info_test, test_construct_more_complex) {
+
+  using namespace testing;
+  // Instrument with two detectors and two path components.
+  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
+  EXPECT_CALL(*pMockInstrumentTree, nPathComponents())
+      .WillRepeatedly(testing::Return(2));
+
+  // These are positions to be returned by the instrument (From all components).
+  std::vector<Eigen::Vector3d> positions;
+  positions.push_back({1, 0, 0});
+  positions.push_back({2, 0, 0});
+  positions.push_back({3, 0, 0});
+  positions.push_back({4, 0, 0});
+
+  EXPECT_CALL(*pMockInstrumentTree, startPositions())
+      .WillRepeatedly(testing::Return(positions));
+  EXPECT_CALL(*pMockInstrumentTree, startRotations())
+      .WillRepeatedly(testing::Return(std::vector<Eigen::Quaterniond>(
+          4, Eigen::Quaterniond(Eigen::Affine3d::Identity().rotation()))));
+  EXPECT_CALL(*pMockInstrumentTree, startEntryPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(4, {0, 0, 0})));
+  EXPECT_CALL(*pMockInstrumentTree, startExitPoints())
+      .WillRepeatedly(
+          testing::Return(std::vector<Eigen::Vector3d>(4, {0, 0, 0})));
+  // Only index 2 and 3 of components are path components
+  EXPECT_CALL(*pMockInstrumentTree, pathComponentIndexes())
+      .WillRepeatedly(testing::Return(std::vector<size_t>({2, 3})));
+
+  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
+  PathComponentInfo<MockFlatTree> pathComponentInfo(mockInstrumentTree);
+
+  EXPECT_EQ(pathComponentInfo.position(0), (Eigen::Vector3d{3, 0, 0}));
+  EXPECT_EQ(pathComponentInfo.position(1), (Eigen::Vector3d{4, 0, 0}));
+  EXPECT_TRUE(testing::Mock::VerifyAndClear(pMockInstrumentTree))
+      << "InstrumentTree used incorrectly";
+}
+
+TEST(path_info_test, test_out_of_bounds_access) {
+
+  using namespace testing;
+  // Instrument with single path component.
+  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
+
+  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
+  PathComponentInfo<MockFlatTree> pathComponentInfo(mockInstrumentTree);
+
+  // All of these should be fine. Single index instrument.
+  EXPECT_NO_THROW(pathComponentInfo.position(0));
+  EXPECT_NO_THROW(pathComponentInfo.entryPoint(0));
+  EXPECT_NO_THROW(pathComponentInfo.exitPoint(0));
+  EXPECT_NO_THROW(pathComponentInfo.rotation(0));
+
+  // All of these will be out of bounds
+
+  EXPECT_THROW(pathComponentInfo.position(1), std::out_of_range);
+  EXPECT_THROW(pathComponentInfo.entryPoint(1), std::out_of_range);
+  EXPECT_THROW(pathComponentInfo.exitPoint(1), std::out_of_range);
+  EXPECT_THROW(pathComponentInfo.rotation(1), std::out_of_range);
+
+  EXPECT_TRUE(testing::Mock::VerifyAndClear(pMockInstrumentTree))
+      << "InstrumentTree used incorrectly";
+}
+
+TEST(path_info_test, test_rotation) {
+  // TODO
+}
+
+TEST(path_info_test, test_position) {
+  // TODO
+}
+}

--- a/cow_instrument/testing/SpectrumInfoTest.cpp
+++ b/cow_instrument/testing/SpectrumInfoTest.cpp
@@ -71,7 +71,7 @@ TEST(spectrum_info_test, test_l2) {
       std::make_shared<testing::NiceMock<MockFlatTree>>(nDetectors);
 
   EXPECT_CALL(*instrument.get(), startPositions())
-      .WillOnce(Return(std::vector<Eigen::Vector3d>{{0, 0, 40}}));
+      .WillRepeatedly(Return(std::vector<Eigen::Vector3d>{{0, 0, 40}}));
   EXPECT_CALL(*instrument.get(), detectorComponentIndexes())
       .WillRepeatedly(testing::Return(std::vector<size_t>(1, 0)));
 
@@ -105,7 +105,8 @@ TEST(spectrum_info_test, test_l2_mapped) {
       std::make_shared<testing::NiceMock<MockFlatTree>>(nDetectors);
 
   EXPECT_CALL(*instrument.get(), startPositions())
-      .WillOnce(Return(std::vector<Eigen::Vector3d>{{0, 0, 40}, {0, 0, 30}}));
+      .WillRepeatedly(
+          Return(std::vector<Eigen::Vector3d>{{0, 0, 40}, {0, 0, 30}}));
   EXPECT_CALL(*instrument.get(), detectorComponentIndexes())
       .WillRepeatedly(testing::Return(std::vector<size_t>{0, 1}));
 

--- a/cow_instrument/testing/SpectrumInfoTest.cpp
+++ b/cow_instrument/testing/SpectrumInfoTest.cpp
@@ -9,11 +9,10 @@ namespace {
 TEST(spectrum_info_test, test_constructor_lhr) {
   std::vector<Spectrum> spectra{{0}, {1}, {2}};
   size_t nDetectors = 3;
-  auto instrument =
-      std::make_shared<testing::NiceMock<MockFlatTree>>(nDetectors);
-  DetectorInfoWithMockInstrument detectorInfo{
-      instrument, SourceSampleDetectorPathFactory<MockFlatTree>{}};
-  SpectrumInfo<MockFlatTree> spectrumInfo(spectra, detectorInfo);
+  auto instrument = std::make_shared<NiceMockInstrumentTree>(nDetectors);
+  DetectorInfoWithNiceMockInstrument detectorInfo{
+      instrument, SourceSampleDetectorPathFactory<NiceMockInstrumentTree>{}};
+  SpectrumInfo<NiceMockInstrumentTree> spectrumInfo(spectra, detectorInfo);
 
   EXPECT_EQ(3, spectrumInfo.size());
   EXPECT_EQ(3, spectrumInfo.nDetectors());


### PR DESCRIPTION
The simplification here is to store positions, rotations and any derived geometry information local to each cache level rather than in the global `ComponentInfo`. `ComponentInfo` is now a convenience map ing layer, which will mainly support `move` and `rotate` type algorithms and drawing. `ComponentInfo` now wraps `DetectorInfo` and the new `PathInfo` caching objects. `ComponentInfo` can coordinate changes to both of these, although `DetectorInfo` owns `PathInfo` and that allows synchronisation of things like L1 and L2 on the `DetectorInfo` after any `PathInfo` component (say a source) has been moved. `PathInfo` also now allows us to correctly update the `Entry` and `Exit` vectors when one of these components is transformed, with minimal memory overhead.

For scanning, because `DetectorInfo` now locally stores it's rotations and position vectors, it should make storing a simple time indexed map (supporting both positions and derived information such as l2) much easier.

