### PR TITLE
AssemblyInfo Pre-ComponentInfo scanning

### DIFF
--- a/cow_instrument/AssemblyInfo.h
+++ b/cow_instrument/AssemblyInfo.h
@@ -1,0 +1,107 @@
+#ifndef ASSEMBLYINFO_H
+#define ASSEMBLYINFO_H
+
+#include <vector>
+#include <memory>
+#include "cow_ptr.h"
+#include "Eigen/Core"
+/**
+ * Provides a component assembly
+ */
+template <typename InstTree> class AssemblyInfo {
+public:
+  AssemblyInfo();
+  explicit AssemblyInfo(const InstTree &instrumentTree);
+  Eigen::Quaterniond rotation(size_t assemblyIndex) const;
+  Eigen::Vector3d position(size_t assemblyIndex) const;
+  void moveAssemblyComponents(const std::vector<size_t> &assemblyIndexes,
+                              const Eigen::Vector3d &offset);
+  void rotateAssemblyComponents(const std::vector<size_t> &assemblyIndexes,
+                                const Eigen::Vector3d &axis,
+                                const double &theta,
+                                const Eigen::Vector3d &center);
+
+private:
+  /// Inverted map to get branch node indexes from component indexes
+  std::vector<int64_t> m_componentToBranchNodeIndex;
+  /// Locally (branch node) indexed positions
+  CowPtr<std::vector<Eigen::Vector3d>> m_positions;
+  /// Locally (branch node) indexed rotations
+  CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
+};
+
+template <typename InstTree>
+AssemblyInfo<InstTree>::AssemblyInfo(const InstTree &instrumentTree)
+    : m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
+          instrumentTree.nBranchNodeComponents())),
+      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
+          instrumentTree.nBranchNodeComponents())) {
+  /*
+   * We should fix that so that temporary copies of the rotation and
+   * position vectors are not required. i.e. make them return by const ref.
+   * However I'm not doing that at the moment because the Mocking
+   * layer has grown significantly and these changes will make it quite a lot
+   * more complicated
+   */
+  std::vector<Eigen::Vector3d> allComponentPositions =
+      instrumentTree.startPositions();
+  std::vector<Eigen::Quaterniond> allComponentRotations =
+      instrumentTree.startRotations();
+
+  size_t i = 0;
+  auto assemblyComponentIndexes = instrumentTree.branchNodeComponentIndexes();
+  for (auto &compIndex : assemblyComponentIndexes) {
+    (*m_positions)[i] = allComponentPositions[compIndex];
+    (*m_rotations)[i] = allComponentRotations[compIndex];
+    ++i;
+  }
+}
+
+template <typename InstTree>
+Eigen::Vector3d AssemblyInfo<InstTree>::position(size_t assemblyIndex) const {
+  return (*m_positions)[assemblyIndex];
+}
+
+template <typename InstTree>
+Eigen::Quaterniond
+AssemblyInfo<InstTree>::rotation(size_t assemblyIndex) const {
+  return (*m_rotations)[assemblyIndex];
+}
+
+template <typename InstTree>
+void AssemblyInfo<InstTree>::moveAssemblyComponents(
+    const std::vector<size_t> &assemblyIndexes, const Eigen::Vector3d &offset) {
+
+  /*
+   * Warning. This method does not translate changes down to sub-components of
+   * the assembly. To do that use ComponentInfo.
+   * AssemblyInfo should only be used internally by ComponentInfo to avoid
+   * danger.
+   */
+  for (auto &assemblyIndex : assemblyIndexes) {
+    (*m_positions)[assemblyIndex] += offset;
+  }
+}
+template <typename InstTree>
+void AssemblyInfo<InstTree>::rotateAssemblyComponents(
+    const std::vector<size_t> &assemblyIndexes, const Eigen::Vector3d &axis,
+    const double &theta, const Eigen::Vector3d &center) {
+
+  /*
+   * Warning. This method does not apply changes down to sub-components of the
+   * assembly. To do that use ComponentInfo.
+   * AssemblyInfo should only be used internally by ComponentInfo to avoid
+   * danger.
+   */
+  using namespace Eigen;
+  const auto transform =
+      Translation3d(center) * AngleAxisd(theta, axis) * Translation3d(-center);
+  const auto rotation = transform.rotation();
+  for (auto &assemblyIndex : assemblyIndexes) {
+
+    (*m_positions)[assemblyIndex] = transform * (*m_positions)[assemblyIndex];
+    (*m_rotations)[assemblyIndex] = rotation * (*m_rotations)[assemblyIndex];
+  }
+}
+#
+#endif

--- a/cow_instrument/CMakeLists.txt
+++ b/cow_instrument/CMakeLists.txt
@@ -28,6 +28,7 @@ set ( SOURCE_FILES
 
 
 set ( INCLUDE_FILES
+                   AssemblyInfo.h
                    Bool.h
                    Component.h
                    ComponentInfo.h

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -9,7 +9,7 @@
 #include <cmath>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
+#include "AssemblyInfo.h"
 #include "ComponentProxy.h"
 #include "cow_ptr.h"
 #include "DetectorInfo.h"
@@ -47,6 +47,8 @@ private:
   void makeInvertedMaps();
   /// Detector info
   DetectorInfo<InstTree> m_detectorInfo;
+  /// Assembly info (branched nodes)
+  AssemblyInfo<InstTree> m_assemblyInfo;
   /// Instrument tree
   const InstTree &m_instrumentTree;
   /// Inverted map to get detector indexes from component indexes
@@ -55,27 +57,17 @@ private:
   std::vector<int64_t> m_componentToPathIndex;
   /// Inverted map to get branch node indexes from component indexes
   std::vector<int64_t> m_componentToBranchNodeIndex;
-  /// Locally (branch node) indexed positions
-  CowPtr<std::vector<Eigen::Vector3d>> m_positions;
-  /// Locally (branch node) indexed rotations
-  CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
-  /// branch node component indexes
-  std::shared_ptr<const std::vector<size_t>> m_branchNodeComponentIndexes;
 };
 
 template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &detectorInfo)
+ComponentInfo<InstTree>::ComponentInfo(
+    const DetectorInfo<InstTree> &detectorInfo)
     : m_detectorInfo(detectorInfo),
+      m_assemblyInfo(detectorInfo.const_instrumentTree()),
       m_instrumentTree(m_detectorInfo.const_instrumentTree()),
       m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
       m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree.nBranchNodeComponents())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree.nBranchNodeComponents())),
-      m_branchNodeComponentIndexes(std::make_shared<std::vector<size_t>>(
-          m_instrumentTree.branchNodeComponentIndexes()))
+      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1)
 
 {
 
@@ -83,18 +75,14 @@ ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &detectorInf
 }
 
 template <typename InstTree>
-ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &&detectorInfo)
+ComponentInfo<InstTree>::ComponentInfo(
+    const DetectorInfo<InstTree> &&detectorInfo)
     : m_detectorInfo(std::move(detectorInfo)),
+      m_assemblyInfo(m_detectorInfo.const_instrumentTree()),
       m_instrumentTree(m_detectorInfo.const_instrumentTree()),
       m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
       m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1),
-      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          m_instrumentTree.nBranchNodeComponents())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          m_instrumentTree.nBranchNodeComponents())),
-      m_branchNodeComponentIndexes(std::make_shared<std::vector<size_t>>(
-          m_instrumentTree.branchNodeComponentIndexes()))
+      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1)
 
 {
 
@@ -103,18 +91,6 @@ ComponentInfo<InstTree>::ComponentInfo(const DetectorInfo<InstTree> &&detectorIn
 
 
 template <typename InstrTree> void ComponentInfo<InstrTree>::init() {
-  // TODO. Do this without copying everything!
-  std::vector<Eigen::Vector3d> allComponentPositions =
-      m_instrumentTree.startPositions();
-  std::vector<Eigen::Quaterniond> allComponentRotations =
-      m_instrumentTree.startRotations();
-
-  size_t i = 0;
-  for (auto &compIndex : (*m_branchNodeComponentIndexes)) {
-    (*m_positions)[i] = allComponentPositions[compIndex];
-    (*m_rotations)[i] = allComponentRotations[compIndex];
-    ++i;
-  }
   makeInvertedMaps();
 }
 
@@ -147,8 +123,8 @@ Eigen::Vector3d ComponentInfo<InstTree>::position(size_t componentIndex) const {
   if (pathIndex >= 0) {
     return m_detectorInfo.pathComponentInfo().position(pathIndex);
   }
-  auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
-  return (*m_positions)[branchNodeIndex];
+  auto assemblyIndex = m_componentToBranchNodeIndex[componentIndex];
+  return m_assemblyInfo.position(assemblyIndex);
 }
 
 template <typename InstTree>
@@ -163,8 +139,8 @@ ComponentInfo<InstTree>::rotation(size_t componentIndex) const {
   if (pathIndex >= 0) {
     return m_detectorInfo.pathComponentInfo().rotation(pathIndex);
   }
-  auto branchNodeIndex = m_componentToBranchNodeIndex[componentIndex];
-  return (*m_rotations)[branchNodeIndex];
+  auto assemblyIndex = m_componentToBranchNodeIndex[componentIndex];
+  return m_assemblyInfo.rotation(assemblyIndex);
 }
 
 template <typename InstTree>
@@ -189,9 +165,12 @@ void ComponentInfo<InstTree>::move(size_t componentIndex,
       detectorsToMove; // Cache of detector indexes which will be moved.
   std::vector<size_t> pathComponentsToMove; // Cache of path component indexes
                                             // which will be moved
+  std::vector<size_t> assemblyComponentsToMove; // Cache of assembly component
+                                                // indexes which will be moved.
 
   detectorsToMove.reserve(componentIndexes.size());
   pathComponentsToMove.reserve(componentIndexes.size());
+  assemblyComponentsToMove.reserve(componentIndexes.size());
   for (auto &compIndex : componentIndexes) {
     auto detIndex = m_componentToDetectorIndex[compIndex];
     if (detIndex >= 0) {
@@ -203,12 +182,17 @@ void ComponentInfo<InstTree>::move(size_t componentIndex,
       pathComponentsToMove.push_back(pathIndex);
     }
 
-    auto branchNodeIndex = m_componentToBranchNodeIndex[compIndex];
-    if (branchNodeIndex >= 0) {
-      (*m_positions)[branchNodeIndex] += offset;
+    auto assemblyIndex = m_componentToBranchNodeIndex[compIndex];
+    if (assemblyIndex >= 0) {
+      /*
+       * Note that sub-components of the assembly are handled at the
+       * component-index level (see FlatTree::subTree).
+       */
+      assemblyComponentsToMove.push_back(assemblyIndex);
     }
   }
 
+  m_assemblyInfo.moveAssemblyComponents(assemblyComponentsToMove, offset);
   m_detectorInfo.moveDetectors(detectorsToMove, offset);
   m_detectorInfo.movePathComponents(pathComponentsToMove, offset);
 }
@@ -227,9 +211,11 @@ void ComponentInfo<InstTree>::rotate(size_t componentIndex,
       detectorsToRotate; // Cache of detector indexes which will be rotated.
   std::vector<size_t> pathComponentsToRotate; // Cache of path component indexes
                                               // which will be rotated
-
+  std::vector<size_t>
+      assemblyComponentsToRotate; // Cache of assembly indexes to rotate
   detectorsToRotate.reserve(componentIndexes.size());
   pathComponentsToRotate.reserve(componentIndexes.size());
+  assemblyComponentsToRotate.reserve(componentIndexes.size());
   for (auto &compIndex : componentIndexes) {
     auto detIndex = m_componentToDetectorIndex[compIndex];
     if (detIndex >= 0) {
@@ -241,20 +227,14 @@ void ComponentInfo<InstTree>::rotate(size_t componentIndex,
       pathComponentsToRotate.push_back(pathIndex);
     }
 
-    auto branchNodeIndex = m_componentToBranchNodeIndex[compIndex];
-    if (branchNodeIndex >= 0) {
-      using namespace Eigen;
-      const auto transform = Translation3d(center) * AngleAxisd(theta, axis) *
-                             Translation3d(-center);
-      const auto rotation = transform.rotation();
-
-      (*m_positions)[branchNodeIndex] =
-          transform * (*m_positions)[branchNodeIndex];
-      (*m_rotations)[branchNodeIndex] =
-          rotation * (*m_rotations)[branchNodeIndex];
+    auto assemblyIndex = m_componentToBranchNodeIndex[compIndex];
+    if (assemblyIndex >= 0) {
+      assemblyComponentsToRotate.push_back(assemblyIndex);
     }
   }
 
+  m_assemblyInfo.rotateAssemblyComponents(assemblyComponentsToRotate, axis,
+                                          theta, center);
   m_detectorInfo.rotateDetectors(detectorsToRotate, axis, theta, center);
   m_detectorInfo.rotatePathComponents(pathComponentsToRotate, axis, theta,
                                        center);

--- a/cow_instrument/testing/EigenTest.cpp
+++ b/cow_instrument/testing/EigenTest.cpp
@@ -2,18 +2,7 @@
 #include "Eigen/Geometry"
 #include <cmath>
 
-TEST(eigen_test, rotate_point1) {
-
-  Eigen::Vector3d a{1, 0, 0};
-  double theta = M_PI / 2;
-  Eigen::Quaterniond quat{Eigen::AngleAxisd(theta, Eigen::Vector3d::UnitY())};
-
-  auto b = quat.toRotationMatrix() * a;
-  EXPECT_TRUE(b.isApprox(Eigen::Vector3d{0, 0, -1}, 1e-12))
-      << "Rotated 90 degrees around Y";
-}
-
-TEST(eigen_test, rotate_point2) {
+TEST(eigen_test, rotate_point) {
 
   Eigen::Quaterniond a{0, 1, 0, 0}; // Point, x = 1, y = 0, z = 0
   double theta = M_PI / 2;


### PR DESCRIPTION
I want to try out introducing scanning at various layers. This is hard to do at the moment because `ComponentInfo` is not correctly split. `ComponentInfo` contains positions/rotations for `Assemblies` and this is logically incorrect as compared to the other layers. Following these changes we have.

1. `ComponentInfo` - coordination to sub `Info layers` provides a view onto the Instrument at the `Component` level
2. `AssemblyInfo` - provides a view onto the instrument containing only composite/assembly aspects, such as banks etc.
3. `DetectorInfo` - provides a view onto the instrument containing only leaf `Detectors`
4. `PathInfo` - provides a view on the instrument containing only non-detector leaf components, such as `source`, `samples`, `guides` etc.
5. `SpectrumInfo` - provides a view onto the data/instrument associated with spectrum only.

![dsc_0858](https://cloud.githubusercontent.com/assets/1109536/23299326/1976f01e-fa79-11e6-8303-e83825cc3c25.JPG)