### PR TITLE
View onto componentinfo

### DIFF
--- a/cow_instrument/AssemblyInfo.h
+++ b/cow_instrument/AssemblyInfo.h
@@ -1,6 +1,6 @@
 #ifndef ASSEMBLYINFO_H
 #define ASSEMBLYINFO_H
-
+#include "ComponentInfo.h"
 #include <vector>
 #include <memory>
 #include "cow_ptr.h"
@@ -11,96 +11,67 @@
 template <typename InstTree> class AssemblyInfo {
 public:
   AssemblyInfo();
-  explicit AssemblyInfo(const InstTree &instrumentTree);
+  explicit AssemblyInfo(
+      std::shared_ptr<const ComponentInfo<InstTree>> componentInfo);
   Eigen::Quaterniond rotation(size_t assemblyIndex) const;
   Eigen::Vector3d position(size_t assemblyIndex) const;
-  void moveAssemblyComponents(const std::vector<size_t> &assemblyIndexes,
-                              const Eigen::Vector3d &offset);
-  void rotateAssemblyComponents(const std::vector<size_t> &assemblyIndexes,
-                                const Eigen::Vector3d &axis,
-                                const double &theta,
-                                const Eigen::Vector3d &center);
+  void moveAssemblyComponent(const size_t assemblyIndex,
+                             const Eigen::Vector3d &offset);
+  void rotateAssemblyComponent(const size_t assemblyIndex,
+                               const Eigen::Vector3d &axis, const double &theta,
+                               const Eigen::Vector3d &center);
 
 private:
-  /// Inverted map to get branch node indexes from component indexes
-  std::vector<int64_t> m_componentToBranchNodeIndex;
-  /// Locally (branch node) indexed positions
-  CowPtr<std::vector<Eigen::Vector3d>> m_positions;
-  /// Locally (branch node) indexed rotations
-  CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
+  std::shared_ptr<const ComponentInfo<InstTree>> m_componentInfo;
+  /// Get the component indexes corresponding to branch nodes
+  std::shared_ptr<const std::vector<size_t>> m_assemblyComponentIndexes;
 };
 
 template <typename InstTree>
-AssemblyInfo<InstTree>::AssemblyInfo(const InstTree &instrumentTree)
-    : m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
-          instrumentTree.nBranchNodeComponents())),
-      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
-          instrumentTree.nBranchNodeComponents())) {
-  /*
-   * We should fix that so that temporary copies of the rotation and
-   * position vectors are not required. i.e. make them return by const ref.
-   * However I'm not doing that at the moment because the Mocking
-   * layer has grown significantly and these changes will make it quite a lot
-   * more complicated
-   */
-  std::vector<Eigen::Vector3d> allComponentPositions =
-      instrumentTree.startPositions();
-  std::vector<Eigen::Quaterniond> allComponentRotations =
-      instrumentTree.startRotations();
-
-  size_t i = 0;
-  auto assemblyComponentIndexes = instrumentTree.branchNodeComponentIndexes();
-  for (auto &compIndex : assemblyComponentIndexes) {
-    (*m_positions)[i] = allComponentPositions[compIndex];
-    (*m_rotations)[i] = allComponentRotations[compIndex];
-    ++i;
-  }
+AssemblyInfo<InstTree>::AssemblyInfo(
+    std::shared_ptr<const ComponentInfo<InstTree>> componentInfo)
+    : m_componentInfo(componentInfo),
+      m_assemblyComponentIndexes(std::make_shared<const std::vector<size_t>>(
+          componentInfo->const_instrumentTree().branchNodeComponentIndexes())) {
 }
 
 template <typename InstTree>
 Eigen::Vector3d AssemblyInfo<InstTree>::position(size_t assemblyIndex) const {
-  return (*m_positions)[assemblyIndex];
+  return m_componentInfo->position(m_assemblyComponentIndexes[assemblyIndex]);
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
 AssemblyInfo<InstTree>::rotation(size_t assemblyIndex) const {
-  return (*m_rotations)[assemblyIndex];
+  return m_componentInfo->rotation(m_assemblyComponentIndexes[assemblyIndex]);
 }
 
 template <typename InstTree>
-void AssemblyInfo<InstTree>::moveAssemblyComponents(
-    const std::vector<size_t> &assemblyIndexes, const Eigen::Vector3d &offset) {
+void
+AssemblyInfo<InstTree>::moveAssemblyComponent(const size_t assemblyIndex,
+                                              const Eigen::Vector3d &offset) {
 
-  /*
-   * Warning. This method does not translate changes down to sub-components of
-   * the assembly. To do that use ComponentInfo.
-   * AssemblyInfo should only be used internally by ComponentInfo to avoid
-   * danger.
-   */
-  for (auto &assemblyIndex : assemblyIndexes) {
-    (*m_positions)[assemblyIndex] += offset;
+  const auto topComponentIndex = m_assemblyComponentIndexes[assemblyIndex];
+  const auto componentsToMove =
+      m_componentInfo->const_instrumentTree().subTreeIndexes(topComponentIndex);
+  for (auto &compIndex : componentsToMove) {
+    // TODO. It's likely this would be better done as part of ComponentInfo
+    // directly
+    m_componentInfo->move(compIndex, offset);
   }
 }
 template <typename InstTree>
-void AssemblyInfo<InstTree>::rotateAssemblyComponents(
-    const std::vector<size_t> &assemblyIndexes, const Eigen::Vector3d &axis,
+void AssemblyInfo<InstTree>::rotateAssemblyComponent(
+    const size_t assemblyIndex, const Eigen::Vector3d &axis,
     const double &theta, const Eigen::Vector3d &center) {
 
-  /*
-   * Warning. This method does not apply changes down to sub-components of the
-   * assembly. To do that use ComponentInfo.
-   * AssemblyInfo should only be used internally by ComponentInfo to avoid
-   * danger.
-   */
-  using namespace Eigen;
-  const auto transform =
-      Translation3d(center) * AngleAxisd(theta, axis) * Translation3d(-center);
-  const auto rotation = transform.rotation();
-  for (auto &assemblyIndex : assemblyIndexes) {
-
-    (*m_positions)[assemblyIndex] = transform * (*m_positions)[assemblyIndex];
-    (*m_rotations)[assemblyIndex] = rotation * (*m_rotations)[assemblyIndex];
+  const auto topComponentIndex = m_assemblyComponentIndexes[assemblyIndex];
+  const auto componentsToRotate =
+      m_componentInfo->const_instrumentTree().subTreeIndexes(topComponentIndex);
+  for (auto &compIndex : componentsToRotate) {
+    // TODO. It's likely this would be better done as part of ComponentInfo
+    // directly
+    m_componentInfo->rotate(compIndex, axis, theta, center);
   }
 }
 #

--- a/cow_instrument/AssemblyInfo.h
+++ b/cow_instrument/AssemblyInfo.h
@@ -12,7 +12,7 @@ template <typename InstTree> class AssemblyInfo {
 public:
   AssemblyInfo();
   explicit AssemblyInfo(
-      std::shared_ptr<const ComponentInfo<InstTree>> componentInfo);
+      std::shared_ptr<ComponentInfo<InstTree>> componentInfo);
   Eigen::Quaterniond rotation(size_t assemblyIndex) const;
   Eigen::Vector3d position(size_t assemblyIndex) const;
   void moveAssemblyComponent(const size_t assemblyIndex,
@@ -22,14 +22,14 @@ public:
                                const Eigen::Vector3d &center);
 
 private:
-  std::shared_ptr<const ComponentInfo<InstTree>> m_componentInfo;
+  std::shared_ptr<ComponentInfo<InstTree>> m_componentInfo;
   /// Get the component indexes corresponding to branch nodes
   std::shared_ptr<const std::vector<size_t>> m_assemblyComponentIndexes;
 };
 
 template <typename InstTree>
 AssemblyInfo<InstTree>::AssemblyInfo(
-    std::shared_ptr<const ComponentInfo<InstTree>> componentInfo)
+    std::shared_ptr<ComponentInfo<InstTree>> componentInfo)
     : m_componentInfo(componentInfo),
       m_assemblyComponentIndexes(std::make_shared<const std::vector<size_t>>(
           componentInfo->const_instrumentTree().branchNodeComponentIndexes())) {
@@ -37,13 +37,13 @@ AssemblyInfo<InstTree>::AssemblyInfo(
 
 template <typename InstTree>
 Eigen::Vector3d AssemblyInfo<InstTree>::position(size_t assemblyIndex) const {
-  return m_componentInfo->position(m_assemblyComponentIndexes[assemblyIndex]);
+  return m_componentInfo->position((*m_assemblyComponentIndexes)[assemblyIndex]);
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
 AssemblyInfo<InstTree>::rotation(size_t assemblyIndex) const {
-  return m_componentInfo->rotation(m_assemblyComponentIndexes[assemblyIndex]);
+  return m_componentInfo->rotation((*m_assemblyComponentIndexes)[assemblyIndex]);
 }
 
 template <typename InstTree>
@@ -51,7 +51,7 @@ void
 AssemblyInfo<InstTree>::moveAssemblyComponent(const size_t assemblyIndex,
                                               const Eigen::Vector3d &offset) {
 
-  const auto topComponentIndex = m_assemblyComponentIndexes[assemblyIndex];
+  const auto topComponentIndex = (*m_assemblyComponentIndexes)[assemblyIndex];
   const auto componentsToMove =
       m_componentInfo->const_instrumentTree().subTreeIndexes(topComponentIndex);
   for (auto &compIndex : componentsToMove) {
@@ -65,7 +65,7 @@ void AssemblyInfo<InstTree>::rotateAssemblyComponent(
     const size_t assemblyIndex, const Eigen::Vector3d &axis,
     const double &theta, const Eigen::Vector3d &center) {
 
-  const auto topComponentIndex = m_assemblyComponentIndexes[assemblyIndex];
+  const auto topComponentIndex = (*m_assemblyComponentIndexes)[assemblyIndex];
   const auto componentsToRotate =
       m_componentInfo->const_instrumentTree().subTreeIndexes(topComponentIndex);
   for (auto &compIndex : componentsToRotate) {

--- a/cow_instrument/AssemblyInfo.h
+++ b/cow_instrument/AssemblyInfo.h
@@ -11,8 +11,7 @@
 template <typename InstTree> class AssemblyInfo {
 public:
   AssemblyInfo();
-  explicit AssemblyInfo(
-      std::shared_ptr<ComponentInfo<InstTree>> componentInfo);
+  explicit AssemblyInfo(std::shared_ptr<ComponentInfo<InstTree>> componentInfo);
   Eigen::Quaterniond rotation(size_t assemblyIndex) const;
   Eigen::Vector3d position(size_t assemblyIndex) const;
   void moveAssemblyComponent(const size_t assemblyIndex,
@@ -37,13 +36,15 @@ AssemblyInfo<InstTree>::AssemblyInfo(
 
 template <typename InstTree>
 Eigen::Vector3d AssemblyInfo<InstTree>::position(size_t assemblyIndex) const {
-  return m_componentInfo->position((*m_assemblyComponentIndexes)[assemblyIndex]);
+  return m_componentInfo->position(
+      (*m_assemblyComponentIndexes)[assemblyIndex]);
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
 AssemblyInfo<InstTree>::rotation(size_t assemblyIndex) const {
-  return m_componentInfo->rotation((*m_assemblyComponentIndexes)[assemblyIndex]);
+  return m_componentInfo->rotation(
+      (*m_assemblyComponentIndexes)[assemblyIndex]);
 }
 
 template <typename InstTree>

--- a/cow_instrument/CMakeLists.txt
+++ b/cow_instrument/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 add_subdirectory(testing)
 
-add_subdirectory(benchmark)
+#add_subdirectory(benchmark)
 
 add_subdirectory(mappers)
 

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -9,10 +9,9 @@
 #include <cmath>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include "AssemblyInfo.h"
 #include "ComponentProxy.h"
 #include "cow_ptr.h"
-#include "DetectorInfo.h"
+#include "ScanTime.h"
 
 /**
  * ComponentInfo type. Provides meta-data an behaviour for working with a
@@ -22,8 +21,18 @@
  */
 template <typename InstTree> class ComponentInfo {
 public:
-  explicit ComponentInfo(const DetectorInfo<InstTree> &detectorInfo);
-  explicit ComponentInfo(const DetectorInfo<InstTree> &&detectorInfo);
+  explicit ComponentInfo(const std::shared_ptr<InstTree> &instTree,
+                         ScanTime scanTime = ScanTime{});
+  explicit ComponentInfo(const std::shared_ptr<InstTree> &&instTree,
+                         ScanTime scanTime = ScanTime{});
+
+  template <typename InstSptrType, typename TimeIndexesType,
+            typename ScanTimesType, typename PositionsType,
+            typename RotationsType>
+  explicit ComponentInfo(InstSptrType &&instrumentTree,
+                         TimeIndexesType &&timeIndexes,
+                         ScanTimesType &&scanTimes, PositionsType &&positions,
+                         RotationsType &&rotations);
 
   Eigen::Vector3d position(size_t componentIndex) const;
 
@@ -41,203 +50,119 @@ public:
               const double &theta, const Eigen::Vector3d &center);
 
 private:
-  /// initalization
-  void init();
-  /// Make maps with component index as key.
-  void makeInvertedMaps();
-  /// Detector info
-  DetectorInfo<InstTree> m_detectorInfo;
-  /// Assembly info (branched nodes)
-  AssemblyInfo<InstTree> m_assemblyInfo;
-  /// Instrument tree
-  const InstTree &m_instrumentTree;
-  /// Inverted map to get detector indexes from component indexes
-  std::vector<int64_t> m_componentToDetectorIndex;
-  /// Inverted map to get path component indexes  from component indexes
-  std::vector<int64_t> m_componentToPathIndex;
-  /// Inverted map to get branch node indexes from component indexes
-  std::vector<int64_t> m_componentToBranchNodeIndex;
+  std::shared_ptr<InstTree> m_instrumentTree;
+
+  /// Locally (component) indexed positions
+  CowPtr<std::vector<Eigen::Vector3d>> m_positions;
+  /// Locally (component) indexed rotations
+  CowPtr<std::vector<Eigen::Quaterniond>> m_rotations;
+  /// Linear index map (component indexed)
+  std::shared_ptr<const std::vector<std::vector<size_t>>> m_linearIndexMap;
+  /// Scan durations
+  std::shared_ptr<const ScanTimes> m_durations;
+  /// Path component information
+  bool m_isScanning = false;
 };
 
+namespace {
+template <typename InstSptrType>
+std::shared_ptr<std::vector<std::vector<size_t>>>
+makeDefaultComponentIndexes(InstSptrType &instrumentTree) {
+  size_t size = instrumentTree->componentSize();
+  auto indexes = std::make_shared<std::vector<std::vector<size_t>>>(size);
+  for (size_t i = 0; i < size; ++i) {
+    // Always one time index per component. Just need the component index.
+    (*indexes)[i] = std::vector<size_t>(1, i);
+  }
+  return indexes;
+}
+}
+
 template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
-    const DetectorInfo<InstTree> &detectorInfo)
-    : m_detectorInfo(detectorInfo),
-      m_assemblyInfo(detectorInfo.const_instrumentTree()),
-      m_instrumentTree(m_detectorInfo.const_instrumentTree()),
-      m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1)
-
-{
-
-  init();
-}
+    const std::shared_ptr<InstTree> &&instrumentTree, ScanTime scanTime)
+    : m_instrumentTree(std::move(instrumentTree)),
+      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
+          m_instrumentTree->startPositions())),
+      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
+          m_instrumentTree->startRotations())),
+      m_linearIndexMap(makeDefaultComponentIndexes(instrumentTree)),
+      m_durations(std::make_shared<const ScanTimes>(1, scanTime)) {}
 
 template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
-    const DetectorInfo<InstTree> &&detectorInfo)
-    : m_detectorInfo(std::move(detectorInfo)),
-      m_assemblyInfo(m_detectorInfo.const_instrumentTree()),
-      m_instrumentTree(m_detectorInfo.const_instrumentTree()),
-      m_componentToDetectorIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToPathIndex(m_instrumentTree.componentSize(), -1),
-      m_componentToBranchNodeIndex(m_instrumentTree.componentSize(), -1)
+    const std::shared_ptr<InstTree> &instrumentTree, ScanTime scanTime)
+    : m_instrumentTree(instrumentTree),
+      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
+          m_instrumentTree->startPositions())),
+      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
+          m_instrumentTree->startRotations())),
+      m_linearIndexMap(makeDefaultComponentIndexes(instrumentTree)),
+      m_durations(std::make_shared<const ScanTimes>(1, scanTime)) {}
 
-{
+template <typename InstTree>
+template <typename InstSptrType, typename TimeIndexesType,
+          typename ScanTimesType, typename PositionsType,
+          typename RotationsType>
+ComponentInfo<InstTree>::ComponentInfo(InstSptrType &&instrumentTree,
+                                       TimeIndexesType &&timeIndexes,
+                                       ScanTimesType &&scanTimes,
+                                       PositionsType &&positions,
+                                       RotationsType &&rotations)
+    : m_instrumentTree(std::forward<InstSptrType>(instrumentTree)),
+      m_linearIndexMap(std::make_shared<std::vector<std::vector<size_t>>>(
+          std::forward<TimeIndexesType>(timeIndexes))),
+      m_durations(
+          std::make_shared<ScanTimes>(std::forward<ScanTimesType>(scanTimes))),
+      m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
+          std::forward<PositionsType>(positions))),
+      m_rotations(std::make_shared<std::vector<Eigen::Quaterniond>>(
+          std::forward<RotationsType>(rotations))) {
 
-  init();
-}
-
-
-template <typename InstrTree> void ComponentInfo<InstrTree>::init() {
-  makeInvertedMaps();
-}
-
-template <typename InstTree> void ComponentInfo<InstTree>::makeInvertedMaps() {
-
-  // Invert the map. Allows us to use component index as a key.
-  auto detToComponent = m_instrumentTree.detectorComponentIndexes();
-  auto pathToComponent = m_instrumentTree.pathComponentIndexes();
-  auto branchNodeToComponent = m_instrumentTree.branchNodeComponentIndexes();
-  for (size_t i = 0; i < detToComponent.size(); ++i) {
-    m_componentToDetectorIndex[detToComponent[i]] = i;
-  }
-  for (size_t i = 0; i < pathToComponent.size(); ++i) {
-    m_componentToPathIndex[pathToComponent[i]] = i;
-  }
-  for (size_t i = 0; i < branchNodeToComponent.size(); ++i) {
-    m_componentToBranchNodeIndex[branchNodeToComponent[i]] = i;
+  if (m_positions->size() != m_rotations->size()) {
+    throw std::invalid_argument(
+        "The numbers of rotations and positions should match");
   }
 }
 
 template <typename InstTree>
 Eigen::Vector3d ComponentInfo<InstTree>::position(size_t componentIndex) const {
-
-  auto detIndex = m_componentToDetectorIndex[componentIndex];
-  if (detIndex >= 0) {
-    return m_detectorInfo.position(detIndex);
-  }
-
-  auto pathIndex = m_componentToPathIndex[componentIndex];
-  if (pathIndex >= 0) {
-    return m_detectorInfo.pathComponentInfo().position(pathIndex);
-  }
-  auto assemblyIndex = m_componentToBranchNodeIndex[componentIndex];
-  return m_assemblyInfo.position(assemblyIndex);
+  return (*m_positions)[componentIndex];
 }
 
 template <typename InstTree>
 Eigen::Quaterniond
 ComponentInfo<InstTree>::rotation(size_t componentIndex) const {
-  auto detIndex = m_componentToDetectorIndex[componentIndex];
-  if (detIndex >= 0) {
-    return m_detectorInfo.rotation(detIndex);
-  }
-
-  auto pathIndex = m_componentToPathIndex[componentIndex];
-  if (pathIndex >= 0) {
-    return m_detectorInfo.pathComponentInfo().rotation(pathIndex);
-  }
-  auto assemblyIndex = m_componentToBranchNodeIndex[componentIndex];
-  return m_assemblyInfo.rotation(assemblyIndex);
+  return (*m_rotations)[componentIndex];
 }
 
 template <typename InstTree>
 size_t ComponentInfo<InstTree>::componentSize() const {
-  return m_instrumentTree.componentSize();
+  return m_instrumentTree->componentSize();
 }
 
 template <typename InstTree>
 const InstTree &ComponentInfo<InstTree>::const_instrumentTree() const {
-  return m_instrumentTree;
+  return *m_instrumentTree;
 }
 
 template <typename InstTree>
 void ComponentInfo<InstTree>::move(size_t componentIndex,
                                    const Eigen::Vector3d &offset) {
-
-  // All "connected" component indexes
-  const std::vector<size_t> componentIndexes =
-      m_instrumentTree.subTreeIndexes(componentIndex);
-
-  std::vector<size_t>
-      detectorsToMove; // Cache of detector indexes which will be moved.
-  std::vector<size_t> pathComponentsToMove; // Cache of path component indexes
-                                            // which will be moved
-  std::vector<size_t> assemblyComponentsToMove; // Cache of assembly component
-                                                // indexes which will be moved.
-
-  detectorsToMove.reserve(componentIndexes.size());
-  pathComponentsToMove.reserve(componentIndexes.size());
-  assemblyComponentsToMove.reserve(componentIndexes.size());
-  for (auto &compIndex : componentIndexes) {
-    auto detIndex = m_componentToDetectorIndex[compIndex];
-    if (detIndex >= 0) {
-      detectorsToMove.push_back(detIndex);
-    }
-
-    auto pathIndex = m_componentToPathIndex[compIndex];
-    if (pathIndex >= 0) {
-      pathComponentsToMove.push_back(pathIndex);
-    }
-
-    auto assemblyIndex = m_componentToBranchNodeIndex[compIndex];
-    if (assemblyIndex >= 0) {
-      /*
-       * Note that sub-components of the assembly are handled at the
-       * component-index level (see FlatTree::subTree).
-       */
-      assemblyComponentsToMove.push_back(assemblyIndex);
-    }
-  }
-
-  m_assemblyInfo.moveAssemblyComponents(assemblyComponentsToMove, offset);
-  m_detectorInfo.moveDetectors(detectorsToMove, offset);
-  m_detectorInfo.movePathComponents(pathComponentsToMove, offset);
+  (*m_positions)[componentIndex] += offset;
 }
-
 template <typename InstTree>
 void ComponentInfo<InstTree>::rotate(size_t componentIndex,
                                      const Eigen::Vector3d &axis,
                                      const double &theta,
                                      const Eigen::Vector3d &center) {
 
-  // All "connected" component indexes
-  const std::vector<size_t> componentIndexes =
-      m_instrumentTree.subTreeIndexes(componentIndex);
+  using namespace Eigen;
+  const auto transform =
+      Translation3d(center) * AngleAxisd(theta, axis) * Translation3d(-center);
+  const auto rotation = transform.rotation();
 
-  std::vector<size_t>
-      detectorsToRotate; // Cache of detector indexes which will be rotated.
-  std::vector<size_t> pathComponentsToRotate; // Cache of path component indexes
-                                              // which will be rotated
-  std::vector<size_t>
-      assemblyComponentsToRotate; // Cache of assembly indexes to rotate
-  detectorsToRotate.reserve(componentIndexes.size());
-  pathComponentsToRotate.reserve(componentIndexes.size());
-  assemblyComponentsToRotate.reserve(componentIndexes.size());
-  for (auto &compIndex : componentIndexes) {
-    auto detIndex = m_componentToDetectorIndex[compIndex];
-    if (detIndex >= 0) {
-      detectorsToRotate.push_back(detIndex);
-    }
-
-    auto pathIndex = m_componentToPathIndex[compIndex];
-    if (pathIndex >= 0) {
-      pathComponentsToRotate.push_back(pathIndex);
-    }
-
-    auto assemblyIndex = m_componentToBranchNodeIndex[compIndex];
-    if (assemblyIndex >= 0) {
-      assemblyComponentsToRotate.push_back(assemblyIndex);
-    }
-  }
-
-  m_assemblyInfo.rotateAssemblyComponents(assemblyComponentsToRotate, axis,
-                                          theta, center);
-  m_detectorInfo.rotateDetectors(detectorsToRotate, axis, theta, center);
-  m_detectorInfo.rotatePathComponents(pathComponentsToRotate, axis, theta,
-                                       center);
+  (*m_positions)[componentIndex] = transform * (*m_positions)[componentIndex];
+  (*m_rotations)[componentIndex] = rotation * (*m_rotations)[componentIndex];
 }
-
 #endif

--- a/cow_instrument/ComponentInfo.h
+++ b/cow_instrument/ComponentInfo.h
@@ -21,9 +21,9 @@
  */
 template <typename InstTree> class ComponentInfo {
 public:
-  explicit ComponentInfo(const std::shared_ptr<InstTree> &instTree,
+  explicit ComponentInfo(const std::shared_ptr<const InstTree> &instTree,
                          ScanTime scanTime = ScanTime{});
-  explicit ComponentInfo(const std::shared_ptr<InstTree> &&instTree,
+  explicit ComponentInfo(const std::shared_ptr<const InstTree> &&instTree,
                          ScanTime scanTime = ScanTime{});
 
   template <typename InstSptrType, typename TimeIndexesType,
@@ -50,7 +50,7 @@ public:
               const double &theta, const Eigen::Vector3d &center);
 
 private:
-  std::shared_ptr<InstTree> m_instrumentTree;
+  std::shared_ptr<const InstTree> m_instrumentTree;
 
   /// Locally (component) indexed positions
   CowPtr<std::vector<Eigen::Vector3d>> m_positions;
@@ -80,7 +80,7 @@ makeDefaultComponentIndexes(InstSptrType &instrumentTree) {
 
 template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
-    const std::shared_ptr<InstTree> &&instrumentTree, ScanTime scanTime)
+    const std::shared_ptr<const InstTree> &&instrumentTree, ScanTime scanTime)
     : m_instrumentTree(std::move(instrumentTree)),
       m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
           m_instrumentTree->startPositions())),
@@ -91,7 +91,7 @@ ComponentInfo<InstTree>::ComponentInfo(
 
 template <typename InstTree>
 ComponentInfo<InstTree>::ComponentInfo(
-    const std::shared_ptr<InstTree> &instrumentTree, ScanTime scanTime)
+    const std::shared_ptr<const InstTree> &instrumentTree, ScanTime scanTime)
     : m_instrumentTree(instrumentTree),
       m_positions(std::make_shared<std::vector<Eigen::Vector3d>>(
           m_instrumentTree->startPositions())),

--- a/cow_instrument/testing/AssemblyInfoTest.cpp
+++ b/cow_instrument/testing/AssemblyInfoTest.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include "AssemblyInfo.h"
+#include "CompositeComponent.h"
+#include "DetectorComponent.h"
+#include "FlatTree.h"
+#include "PointSample.h"
+#include "PointSource.h"
+#include <Eigen/Core>
+
+namespace {
+
+std::shared_ptr<const FlatTree> makeInstrumentTree() {
+
+  /*
+
+        A
+        |
+ ------------------------------
+ |                |           |
+ B                C           D
+
+
+  */
+
+  auto a = std::make_shared<CompositeComponent>(ComponentIdType(1));
+  a->addComponent(std::unique_ptr<DetectorComponent>(new DetectorComponent(
+      ComponentIdType(2), DetectorIdType(1), Eigen::Vector3d{1, 1, 1})));
+  a->addComponent(std::unique_ptr<PointSource>(
+      new PointSource(Eigen::Vector3d{-1, 0, 0}, ComponentIdType(3))));
+
+  a->addComponent(std::unique_ptr<PointSample>(
+      new PointSample(Eigen::Vector3d{0.1, 0, 0}, ComponentIdType(5))));
+
+  return std::make_shared<const FlatTree>(a);
+}
+
+TEST(assembly_info_test, test_construction) {
+  auto instrumentTree = makeInstrumentTree();
+  auto componentInfo =
+      std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
+  AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+}
+}

--- a/cow_instrument/testing/AssemblyInfoTest.cpp
+++ b/cow_instrument/testing/AssemblyInfoTest.cpp
@@ -52,10 +52,11 @@ TEST(assembly_info_test, test_positions) {
       std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
   AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
 
-  EXPECT_TRUE(assemblyInfo.position(0).isApprox(componentInfo->position(0))) << "Assembly 0 is same as Component 0";
-  EXPECT_TRUE(assemblyInfo.position(1).isApprox(componentInfo->position(3))) << "Assembly 1 is same as Component 3";
+  EXPECT_TRUE(assemblyInfo.position(0).isApprox(componentInfo->position(0)))
+      << "Assembly 0 is same as Component 0";
+  EXPECT_TRUE(assemblyInfo.position(1).isApprox(componentInfo->position(3)))
+      << "Assembly 1 is same as Component 3";
 }
-
 
 TEST(assembly_info_test, test_rotations) {
   auto instrumentTree = makeInstrumentTree();
@@ -63,22 +64,26 @@ TEST(assembly_info_test, test_rotations) {
       std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
   AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
 
-  EXPECT_TRUE(assemblyInfo.rotation(0).isApprox(componentInfo->rotation(0))) << "Assembly 0 is same as Component 0";
-  EXPECT_TRUE(assemblyInfo.rotation(1).isApprox(componentInfo->rotation(3))) << "Assembly 1 is same as Component 3";
+  EXPECT_TRUE(assemblyInfo.rotation(0).isApprox(componentInfo->rotation(0)))
+      << "Assembly 0 is same as Component 0";
+  EXPECT_TRUE(assemblyInfo.rotation(1).isApprox(componentInfo->rotation(3)))
+      << "Assembly 1 is same as Component 3";
 }
-TEST(assembly_info_test, test_move){
+TEST(assembly_info_test, test_move) {
 
-    auto instrumentTree = makeInstrumentTree();
-    auto componentInfo =
-        std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
-    AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+  auto instrumentTree = makeInstrumentTree();
+  auto componentInfo =
+      std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
+  AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
 
-    auto currentRootPos = assemblyInfo.position(0); // root position
-    auto currentLeafPos = componentInfo->position(1);
-    Eigen::Vector3d delta{1, 0, 0};
-    assemblyInfo.moveAssemblyComponent(0, delta);
+  auto currentRootPos = assemblyInfo.position(0); // root position
+  auto currentLeafPos = componentInfo->position(1);
+  Eigen::Vector3d delta{1, 0, 0};
+  assemblyInfo.moveAssemblyComponent(0, delta);
 
-    EXPECT_TRUE(assemblyInfo.position(0).isApprox(currentRootPos + delta)) << "Test root moved";
-    EXPECT_TRUE(componentInfo->position(1).isApprox(currentLeafPos + delta)) << "Test leaf moved. Changes should be progated down.";
+  EXPECT_TRUE(assemblyInfo.position(0).isApprox(currentRootPos + delta))
+      << "Test root moved";
+  EXPECT_TRUE(componentInfo->position(1).isApprox(currentLeafPos + delta))
+      << "Test leaf moved. Changes should be progated down.";
 }
 }

--- a/cow_instrument/testing/AssemblyInfoTest.cpp
+++ b/cow_instrument/testing/AssemblyInfoTest.cpp
@@ -9,8 +9,7 @@
 
 namespace {
 
-std::shared_ptr<const FlatTree> makeInstrumentTree() {
-
+std::shared_ptr<FlatTree> makeInstrumentTree() {
   /*
 
         A
@@ -18,6 +17,8 @@ std::shared_ptr<const FlatTree> makeInstrumentTree() {
  ------------------------------
  |                |           |
  B                C           D
+                              |
+                              E
 
 
   */
@@ -28,10 +29,14 @@ std::shared_ptr<const FlatTree> makeInstrumentTree() {
   a->addComponent(std::unique_ptr<PointSource>(
       new PointSource(Eigen::Vector3d{-1, 0, 0}, ComponentIdType(3))));
 
-  a->addComponent(std::unique_ptr<PointSample>(
+  auto d = std::unique_ptr<CompositeComponent>(
+      new CompositeComponent(ComponentIdType(4)));
+  d->addComponent(std::unique_ptr<PointSample>(
       new PointSample(Eigen::Vector3d{0.1, 0, 0}, ComponentIdType(5))));
 
-  return std::make_shared<const FlatTree>(a);
+  a->addComponent(std::move(d));
+
+  return std::make_shared<FlatTree>(a);
 }
 
 TEST(assembly_info_test, test_construction) {
@@ -39,5 +44,41 @@ TEST(assembly_info_test, test_construction) {
   auto componentInfo =
       std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
   AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+}
+
+TEST(assembly_info_test, test_positions) {
+  auto instrumentTree = makeInstrumentTree();
+  auto componentInfo =
+      std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
+  AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+
+  EXPECT_TRUE(assemblyInfo.position(0).isApprox(componentInfo->position(0))) << "Assembly 0 is same as Component 0";
+  EXPECT_TRUE(assemblyInfo.position(1).isApprox(componentInfo->position(3))) << "Assembly 1 is same as Component 3";
+}
+
+
+TEST(assembly_info_test, test_rotations) {
+  auto instrumentTree = makeInstrumentTree();
+  auto componentInfo =
+      std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
+  AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+
+  EXPECT_TRUE(assemblyInfo.rotation(0).isApprox(componentInfo->rotation(0))) << "Assembly 0 is same as Component 0";
+  EXPECT_TRUE(assemblyInfo.rotation(1).isApprox(componentInfo->rotation(3))) << "Assembly 1 is same as Component 3";
+}
+TEST(assembly_info_test, test_move){
+
+    auto instrumentTree = makeInstrumentTree();
+    auto componentInfo =
+        std::make_shared<ComponentInfo<FlatTree>>(instrumentTree);
+    AssemblyInfo<FlatTree> assemblyInfo{componentInfo};
+
+    auto currentRootPos = assemblyInfo.position(0); // root position
+    auto currentLeafPos = componentInfo->position(1);
+    Eigen::Vector3d delta{1, 0, 0};
+    assemblyInfo.moveAssemblyComponent(0, delta);
+
+    EXPECT_TRUE(assemblyInfo.position(0).isApprox(currentRootPos + delta)) << "Test root moved";
+    EXPECT_TRUE(componentInfo->position(1).isApprox(currentLeafPos + delta)) << "Test leaf moved. Changes should be progated down.";
 }
 }

--- a/cow_instrument/testing/CMakeLists.txt
+++ b/cow_instrument/testing/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 include_directories(${GTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${MPI_CXX_INCLUDE_PATH})
 
 set ( TEST_FILES
+                 AssemblyInfoTest.cpp
                  CompositeComponentTest.cpp
                  ComponentInfoTest.cpp
                  ComponentProxyTest.cpp

--- a/cow_instrument/testing/ComponentInfoTest.cpp
+++ b/cow_instrument/testing/ComponentInfoTest.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<FlatTree> makeInstrumentTree() {
 
   return std::make_shared<FlatTree>(a);
 }
-
+/*
 TEST(component_info_test, test_construct) {
 
   using namespace testing;
@@ -72,7 +72,8 @@ TEST(component_info_test, test_move) {
       .WillOnce(Return(std::vector<size_t>{0}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{DetectorInfo<NiceMockInstrumentTree>(
+  auto componentInfo =
+ComponentInfoWithNiceMockInstrument{DetectorInfo<NiceMockInstrumentTree>(
           mockInstrumentTree)};
 
   auto before = componentInfo.position(0);
@@ -218,6 +219,7 @@ TEST(component_info_test, test_single_rotation_around_arbitrary_center) {
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
       << "Internal component rotation not updated correctly";
 }
+*/
 
 TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
 
@@ -240,9 +242,7 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
           Eigen::Quaterniond{Eigen::Affine3d::Identity().rotation()}}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      DetectorInfo<NiceMockInstrumentTree>(
-          mockInstrumentTree)};
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{mockInstrumentTree};
   const size_t sampleComponentIndex = 0;
 
   // Rotate once by 90 degrees around z should put detector at 0,1,0
@@ -268,9 +268,7 @@ TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
 
 TEST(component_info_test, test_position) {
 
-  auto detectorInfo = DetectorInfo<FlatTree>(makeInstrumentTree());
-
-  ComponentInfo<FlatTree> componentInfo(detectorInfo);
+  ComponentInfo<FlatTree> componentInfo(makeInstrumentTree());
 
   auto posB = componentInfo.position(1); // Detector
   auto posC = componentInfo.position(2); // path component (source)
@@ -288,5 +286,23 @@ TEST(component_info_test, test_position) {
   EXPECT_EQ(posA, (posB + posC + posE) / 3);
   EXPECT_NE(posA, (posB + posC + posE + posD) / 4)
       << "Composites (posD) should not be factored in";
+}
+
+TEST(component_info_test, test_scanning_constructor) {
+  auto scanTimes = ScanTimes{ScanTime(0, 10), ScanTime(10, 20)}; // 2 scan times
+
+  auto timeIndexes = std::vector<std::vector<size_t>>{{0, 2}, {1, 3}};
+
+  auto positions = std::vector<Eigen::Vector3d>(4);
+  positions[0] = Eigen::Vector3d{1, 0, 0};    // Detector B time 0
+  positions[1] = Eigen::Vector3d{1, 2, 0};    // Detector C time 0
+  positions[2] = Eigen::Vector3d{1.01, 0, 0}; // Detector B time 1
+  positions[3] = Eigen::Vector3d{1.01, 2, 0}; // Detector C time 1
+
+  auto rotations = std::vector<Eigen::Quaterniond>(
+      4, Eigen::Quaterniond{Eigen::Affine3d::Identity().rotation()});
+
+  ComponentInfo<FlatTree> componentInfo(makeInstrumentTree(), timeIndexes,
+                                        scanTimes, positions, rotations);
 }
 }

--- a/cow_instrument/testing/ComponentInfoTest.cpp
+++ b/cow_instrument/testing/ComponentInfoTest.cpp
@@ -44,37 +44,15 @@ std::shared_ptr<FlatTree> makeInstrumentTree() {
 
   return std::make_shared<FlatTree>(a);
 }
-/*
-TEST(component_info_test, test_construct) {
-
-  using namespace testing;
-  MockFlatTree *pMockInstrumentTree = new testing::NiceMock<MockFlatTree>{};
-  EXPECT_CALL(*pMockInstrumentTree, nDetectors())
-      .WillRepeatedly(testing::Return(1));
-
-  std::shared_ptr<MockFlatTree> mockInstrumentTree{pMockInstrumentTree};
-
-  ComponentInfoWithMockInstrument{
-      DetectorInfo<MockFlatTree>(mockInstrumentTree)};
-
-  EXPECT_TRUE(testing::Mock::VerifyAndClear(pMockInstrumentTree))
-      << "InstrumentTree used incorrectly";
-}
 
 TEST(component_info_test, test_move) {
 
   using namespace testing;
 
   auto *instrumentTree = new testing::NiceMock<MockFlatTree>{};
-  // configure what the subTreIndexes call will do. i.e. point to the first
-  // component_id
-  EXPECT_CALL(*instrumentTree, subTreeIndexes(_))
-      .WillOnce(Return(std::vector<size_t>{0}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo =
-ComponentInfoWithNiceMockInstrument{DetectorInfo<NiceMockInstrumentTree>(
-          mockInstrumentTree)};
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{mockInstrumentTree};
 
   auto before = componentInfo.position(0);
   auto offset = Eigen::Vector3d{1, 0, 0};
@@ -84,7 +62,6 @@ ComponentInfoWithNiceMockInstrument{DetectorInfo<NiceMockInstrumentTree>(
   EXPECT_EQ(after, before + offset);
   EXPECT_TRUE(Mock::VerifyAndClearExpectations(instrumentTree));
 }
-
 TEST(component_info_test, test_single_rotation_around_component_origin) {
 
   using namespace testing;
@@ -102,9 +79,7 @@ TEST(component_info_test, test_single_rotation_around_component_origin) {
           Eigen::Quaterniond{Eigen::Affine3d::Identity().rotation()}}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      DetectorInfo<NiceMockInstrumentTree>(
-          mockInstrumentTree)};
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{mockInstrumentTree};
 
   const size_t sampleComponentIndex = 0;
 
@@ -150,9 +125,7 @@ TEST(component_info_test, test_multiple_rotation_around_component_origin) {
           Eigen::Quaterniond{Eigen::Affine3d::Identity().rotation()}}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      DetectorInfo<NiceMockInstrumentTree>(
-          mockInstrumentTree)};
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{mockInstrumentTree};
 
   const size_t sampleComponentIndex = 0;
 
@@ -200,9 +173,7 @@ TEST(component_info_test, test_single_rotation_around_arbitrary_center) {
           Eigen::Quaterniond{Eigen::Affine3d::Identity().rotation()}}));
 
   std::shared_ptr<NiceMockInstrumentTree> mockInstrumentTree(instrumentTree);
-  auto componentInfo = ComponentInfoWithNiceMockInstrument{
-      DetectorInfo<NiceMockInstrumentTree>(
-          mockInstrumentTree)};
+  auto componentInfo = ComponentInfoWithNiceMockInstrument{mockInstrumentTree};
   const size_t sampleComponentIndex = 0;
 
   componentInfo.rotate(sampleComponentIndex, rotationAxis, rotationAngle,
@@ -219,8 +190,6 @@ TEST(component_info_test, test_single_rotation_around_arbitrary_center) {
   EXPECT_TRUE(rotatedVector.isApprox(Eigen::Vector3d{0, 1, 0}, 1e-14))
       << "Internal component rotation not updated correctly";
 }
-*/
-
 TEST(component_info_test, test_multiple_rotation_arbitrary_center) {
 
   using namespace testing;


### PR DESCRIPTION
This is WIP. Do not merge.

The idea is to make `AssemblyInfo`, `DetectorInfo` and `PathComponentInfo` views onto `ComponentInfo`. i.e. `ComponentInfo` contains the data and the aforementioned hold the mappings.

Thus far. I have changed `ComponentInfo` and `AssemblyInfo` to work like this but none of the others. I have also disabled the benchmarks until I get everything working again. 

I'll get back to this issue at some point in the near future.